### PR TITLE
Do not fix load in a test intended to measure throughput

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ scripts/stress.sh springboot3/target/springboot3.jar
 For each test, you should see output like 
 
 ```shell
-  6001 requests in 30.002s,   4.84MB read
-Requests/sec: 200.02
-Transfer/sec: 165.29kB
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     9.58ms    6.03ms  94.90ms   85.57%
+    Req/Sec   9936.90   2222.61  10593.00     95.24
 ```
 ### Acceptable: Run on a single machine, with solid automation and detailed output
 

--- a/scripts/stress.sh
+++ b/scripts/stress.sh
@@ -9,6 +9,6 @@ set -euo pipefail
 
 ${thisdir}/infra.sh -s
 java -XX:ActiveProcessorCount=8 -Xms512m -Xmx512m -jar $1 &
-jbang wrk2@hyperfoil -t2 -c100 -d30s -R 200 --latency http://localhost:8080/fruits
+jbang wrk@hyperfoil -t2 -c100 -d20s --timeout 1s http://localhost:8080/fruits
 scripts/infra.sh -d
 kill $(lsof -t -i:8080) &>/dev/null


### PR DESCRIPTION
So I know this conflicts with #18 which has been open for ages, but I spotted that I'd made a copy-paste error in the original scripts, and the stress test script was actually a latency-test script. 