### PR TITLE
Allow script to be called from other directories

### DIFF
--- a/scripts/stress.sh
+++ b/scripts/stress.sh
@@ -8,7 +8,7 @@ kill $(lsof -t -i:8080) &>/dev/null
 set -euo pipefail
 
 ${thisdir}/infra.sh -s
-java -XX:ActiveProcessorCount=8 -Xms512m -Xmx512m -jar $1 &
+java -XX:ActiveProcessorCount=4 -Xms512m -Xmx512m -jar ${thisdir}/../$1 &
 jbang wrk@hyperfoil -t2 -c100 -d20s --timeout 1s http://localhost:8080/fruits
 ${thisdir}/infra.sh -d
 kill $(lsof -t -i:8080) &>/dev/null


### PR DESCRIPTION
I used `$thisdir` sometimes, but not always. 

I also applied @franz1981's suggestion of using fewer cores.