### PR TITLE
Exercise scripts in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,3 +60,26 @@ jobs:
           ./mvnw -B clean verify \
             -Dmaven.compiler.release=${{ matrix.java }} \
             -Djava.version=${{ matrix.java }}
+
+      - name: Setup JBang
+        uses: jbangdev/setup-jbang@main
+
+      - name: Validate simple scripts
+        run: |
+          case "${{ matrix.app }}" in
+            springboot3)
+            TARGET_DIR="${{ matrix.app }}/target/springboot3.jar"
+            ;;
+            quarkus3)
+            TARGET_DIR="${{ matrix.app }}/target/quarkus-app/quarkus-run.jar"
+            ;;
+            quarkus3-spring-compatibility)
+            TARGET_DIR="${{ matrix.app }}/target/quarkus-app/quarkus-run.jar"
+            ;;
+            *)
+            echo "Unknown app: ${{ matrix.app }}"
+            exit 1
+            ;;
+          esac
+          scripts/stress.sh "$TARGET_DIR"
+          scripts/1strequest.sh "java -XX:ActiveProcessorCount=8 -Xms512m -Xmx512m -jar $TARGET_DIR" 5

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ cd scripts
 ## Scripts
 
 There are some [scripts](scripts) available to help you run the application:
-- [`1strequest.sh`](scripts/1strequest.sh)
-    - Runs an application X times and computes the time to 1st request and RSS for each iteration as well as an average over the X iterations.
 - [`run-requests.sh`](scripts/run-requests.sh)
     - Runs a set of requests against a running application.
 - [`infra.sh`](scripts/infra.sh)
@@ -78,6 +76,11 @@ We use [Hyperfoil](https://hyperfoil.io/https://hyperfoil.io/) instead of [wrk](
 
 You can run these in any order. 
 
+#### Throughput 
+
+The [`stress.sh`](scripts/stress.sh) script starts the infrastructure, and uses a load generator to measure
+how many requests the applications can handle over a short period of time. 
+
 ```shell
 scripts/stress.sh quarkus3/target/quarkus-app/quarkus-run.jar
 scripts/stress.sh quarkus3-spring-compatibility/target/quarkus-app/quarkus-run.jar
@@ -91,6 +94,28 @@ For each test, you should see output like
     Latency     9.58ms    6.03ms  94.90ms   85.57%
     Req/Sec   9936.90   2222.61  10593.00     95.24
 ```
+
+#### RSS and time to first request 
+
+
+The [`1strequest.sh`](scripts/1strequest.sh) starts the infrastructure and runs an application X times and computes the time to 1st request and RSS for each iteration as well as an average over the X iterations.
+
+For example, 
+```shell
+scripts/1strequest.sh "java -XX:ActiveProcessorCount=8 -Xms512m -Xmx512m -jar quarkus3/target/quarkus-app/quarkus-run.jar" 5
+scripts/1strequest.sh "java -XX:ActiveProcessorCount=8 -Xms512m -Xmx512m -jar quarkus3-spring-compatibility/target/quarkus-app/quarkus-run.jar" 5
+scripts/1strequest.sh "java -XX:ActiveProcessorCount=8 -Xms512m -Xmx512m -jar springboot3/target/springboot3.jar" 5
+```
+
+You should see output like 
+
+```shell
+-------------------------------------------------
+AVG RSS (after 1st request): 35.2 MB
+AVG time to first request: 0.150 sec
+-------------------------------------------------
+```
+
 ### Acceptable: Run on a single machine, with solid automation and detailed output
 
 These scripts are being developed.

--- a/scripts/1strequest.sh
+++ b/scripts/1strequest.sh
@@ -13,6 +13,8 @@
 # 3) Run the Quarkus with spring compatibility app 10 times
 # $ ./1strequest.sh "java -XX:ActiveProcessorCount=8 -Xms512m -Xmx512m -jar ../quarkus3-spring-compatibility/target/quarkus-app/quarkus-run.jar" 10
 
+thisdir=`dirname "$0"`
+
 COMMAND=$1
 NUM_ITERATIONS=1
 TOTAL_RSS=0
@@ -36,7 +38,7 @@ do
   sync && sudo purge
 
   # Start the infra
-  ./infra.sh -s
+  ${thisdir}/infra.sh -s
 
   ts=$(_date)
   $COMMAND &
@@ -62,7 +64,7 @@ do
   echo "-------------------------------------------------"
 
   # Stop the infra
-  ./infra.sh -d
+  ${thisdir}/infra.sh -d
 done
 
 echo


### PR DESCRIPTION
The simple scripts are part of the public face of this repo, so we want to make sure they keep working. We're having some "works on your machine but not mine" issues reported (hi,  #66) so we do need tests.

I've tacked on an extra job in the CI which runs both scripts. (I debated between this and another workflow, and in the end went for One Big Workflow.)

I've updated `1strequest .sh` to work when invoked from other directories.

I've also slightly rearrange documentation to flow more logically.