### PR TITLE
Handle non-numeric output in timeout script

### DIFF
--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -270,12 +270,16 @@ scripts:
         - script: sync-drop-fs-cache
         - sh: ${{RUNTIME.runCmd}} &>${{REPO_DIR}}/logs/measure-time-to-first-request-${{RUNTIME.name}}-${{ITERATION}}.log &
         - sh: APP_PID=$!
-        - sh: timeout 60s bash -c "taskset --cpu-list ${{config.resources.cpu.1st_request}} ${{HELPER_SCRIPTS_DIR}}/time-to-1st-request.sh ${{TARGET_URL}} | awk '{print $1}'"
+        - sh: timeout 60s bash -c "taskset --cpu-list ${{config.resources.cpu.1st_request}} ${{HELPER_SCRIPTS_DIR}}/time-to-1st-request.sh ${{TARGET_URL}}"
           then:
             - regex: Terminated
               then:
                 - sh: kill -15 $APP_PID
                 - abort: Run ${{RUNTIME.runCmd}} didn't start within allotted timeout
+            - regex: .*\D.*
+              then:
+                - sh: kill -15 $APP_PID
+                - abort: Timeout script returned a non-numeric value
               else:
                 - set-state: START_TIME
         - sh: kill -15 $APP_PID

--- a/scripts/perf-lab/scripts/time-to-1st-request.sh
+++ b/scripts/perf-lab/scripts/time-to-1st-request.sh
@@ -19,4 +19,4 @@ do
 done
 
 TTFR=$((($(_date) - ts)/1000000))
-echo "${TTFR} ms"
+echo "${TTFR}"


### PR DESCRIPTION
also remove redundant 'ms' suffix in time-to-1st-request output