### PR TITLE
Practice active benchmarking

### DIFF
--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -23,6 +23,7 @@ states:
   config.resources.cpu.db: 4-6
   config.resources.cpu.load_generator: 7-9
   config.resources.cpu.1st_request: 10
+  config.resources.cpu.monitor: 11
 
   config.profiler.name: none #jfr flamegraph
   config.profiler.events: cpu
@@ -34,6 +35,7 @@ states:
 
   APP_CMD_PREFIX: taskset --cpu-list ${{config.resources.cpu.app}}
   LOAD_GEN_CMD_PREFIX: taskset --cpu-list ${{config.resources.cpu.load_generator}}
+  MONITOR_CMD_PREFIX: taskset --cpu-list ${{config.resources.cpu.monitor}}
   RUN.WRK_BIN: ${{LOAD_GEN_CMD_PREFIX}} jbang -R -XX:+UseNUMA wrk@hyperfoil
 
   DROP_OS_FILESYSTEM_CACHES:
@@ -399,6 +401,12 @@ scripts:
         - sh: PID=$!
         - sh: echo $PID
         - set-state: JVM_PID
+        - script: monitor-processes
+          with:
+            pid: ${{JVM_PID}}
+            log_dir: ${{REPO_DIR}}/logs
+            runtime_name: ${{RUNTIME.name}}
+            iteration: ${{ITERATION}}
         - log: JVM_PID = ${{JVM_PID}}
         - read-state: ${{config.profiler.name}}
           then:
@@ -472,6 +480,7 @@ scripts:
           with:
             array: RUN.output.results.${{RUNTIME.name}}.load.throughputDensity
             value: ${{= ${{THROUGHPUT}}/${{RSS}}*1024 }}
+        - signal: LOAD_TEST_COMPLETE
         - sh: kill -15 $PID
         - sh: sleep ${{PAUSE_TIME}}
         - script: stop-test-services
@@ -507,6 +516,52 @@ scripts:
         1m:
           - ctrlC
           - abort: Log file ${{log_file}} didn't match regex ${{log_regex}} after 10 minutes
+
+  monitor-processes:
+    - set-signal: LOAD_TEST_COMPLETE 1
+    - script:
+        name: monitor-process
+        async: true
+      with:
+        name: pidstat
+        command: pidstat -u -p ${{pid}} 1
+        log_file: ${{log_dir}}/pidstat-${{runtime_name}}-${{iteration}}.log
+    - script:
+        name: monitor-process
+        async: true
+      with:
+        name: mpstat
+        command: mpstat -P ALL 1
+        log_file: ${{log_dir}}/mpstat-${{runtime_name}}-${{iteration}}.log
+    - script:
+        name: monitor-process
+        async: true
+      with:
+        name: vmstat
+        command: vmstat 1
+        log_file: ${{log_dir}}/vmstat-${{runtime_name}}-${{iteration}}.log
+    - script: monitor-postgres
+
+  monitor-postgres:
+    - sh: POSTGRES_PID=$(${{PROJ_REPO_DIR}}/scripts/infra.sh -r)
+    - sh: echo $POSTGRES_PID
+    - set-state: POSTGRES_PID
+    - script:
+        name: monitor-process
+        async: true
+      with:
+        name: postgres-pidstat
+        command: pidstat -u -p $(pgrep -d , -P ${{POSTGRES_PID}}) 1
+        log_file: ${{log_dir}}/postgres-pidstat-${{runtime_name}}-${{iteration}}.log
+
+  monitor-process:
+    - queue-download: ${{log_file}}
+    - sh: ${{MONITOR_CMD_PREFIX}} ${{command}} &>${{log_file}} &
+    - sh: PROCESS_PID=$!
+    - sh: echo $PROCESS_PID
+    - set-state: PROCESS_PID
+    - wait-for: ${{monitor_complete_signal:LOAD_TEST_COMPLETE}}
+    - sh: kill -15 $PROCESS_PID
 
   download-metrics:
     - sh: mkdir -p ${{METRICS_DIR}}

--- a/scripts/perf-lab/run-benchmarks.sh
+++ b/scripts/perf-lab/run-benchmarks.sh
@@ -172,6 +172,10 @@ local current_cpu=$((current_cpu + 1))
 local db_cpus="${current_cpu}-$((current_cpu + 2))"
 local current_cpu=$((current_cpu + 3))
 local load_gen_cpus="${current_cpu}-$((current_cpu + 2))"
+local current_cpu=$((current_cpu + 3))
+local first_request_cpu="${current_cpu}"
+local current_cpu=$((current_cpu + 1))
+local monitor_cpu="${current_cpu}"
 
 ${JBANG_CMD} qDup@hyperfoil \
     -B ${OUTPUT_DIR} \
@@ -188,6 +192,8 @@ ${JBANG_CMD} qDup@hyperfoil \
     -S config.resources.cpu.app="${app_cpus}" \
     -S config.resources.cpu.db="${db_cpus}" \
     -S config.resources.cpu.load_generator="${load_gen_cpus}" \
+    -S config.resources.cpu.1st_request="${first_request_cpu}" \
+    -S config.resources.cpu.monitor="${monitor_cpu}" \
     -S config.springboot3.version=${SPRING_BOOT3_VERSION} \
     -S config.springboot4.version=${SPRING_BOOT4_VERSION} \
     -S config.jvm.memory="${JVM_MEMORY}" \

--- a/scripts/stress.sh
+++ b/scripts/stress.sh
@@ -20,6 +20,10 @@ set -euo pipefail
 
 ${thisdir}/infra.sh -s
 java -XX:ActiveProcessorCount=4 -Xms512m -Xmx512m -jar ${callingdir}/$1 &
+
+# Give the app a chance to fully start before throwing load at it
+sleep 20
+
 jbang wrk@hyperfoil -t2 -c100 -d20s --timeout 1s http://localhost:8080/fruits
 ${thisdir}/infra.sh -d
 kill $(lsof -t -i:8080) &>/dev/null


### PR DESCRIPTION
- Monitor `pidstat` for the app and database during each iteration
- Monitor `mpstat` and `vmstat` for the entire machine during each iteration

All the monitoring logs are also available as part of the run.

Fixes #62