### PR TITLE
Improve async-profiler script flexibility with dynamic log naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ buildNumber.properties
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
 /.idea/
+/.profileconfig.json

--- a/scripts/perf-lab/helpers/async-profiler.yml
+++ b/scripts/perf-lab/helpers/async-profiler.yml
@@ -46,10 +46,10 @@ scripts:
     - sh: >
         bin/asprof 
         -d ${{duration:10}} 
-        -f ${{REPO_DIR}}/logs/flamegraph.${{suffix:html}} 
+        -f ${{REPO_DIR}}/logs/${{format:flamegraph}}.${{suffix:html}} 
         -o ${{format:flamegraph}} 
         -e ${{events:cpu}} 
         ${{="${{enableTotal : }}".toLowerCase() == "true" ? "--total" : ""}} 
         --title ${{title:async-profiler}} 
         ${{pid}}
-    - download: ${{REPO_DIR}}/logs/flamegraph.${{suffix:html}}
+    - download: ${{REPO_DIR}}/logs/${{format:flamegraph}}.${{suffix:html}}

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -412,7 +412,7 @@ scripts:
                   with:
                     wait_start: LOAD_STEADY_STATE_START
                     pid: ${{JVM_PID}}
-                    suffix: ${{ITERATION}}.html
+                    suffix: "${{ITERATION}}.${{= '${{config.profiler.name}}' == 'jfr' ? 'jfr' : 'html' }}"
                     format: ${{config.profiler.name}}
                     events: ${{config.profiler.events}}
                     delay: 10s


### PR DESCRIPTION
- Adjust log naming strategy to include configurable format and suffix options.
- Update `.gitignore` to exclude `.profileconfig.json`.