### PR TITLE
Support scenario-based result file naming in performance lab script

### DIFF
--- a/scripts/perf-lab/push-results.sh
+++ b/scripts/perf-lab/push-results.sh
@@ -73,9 +73,17 @@ push_results() {
   jq 'del(.env.run)' ${resultsDir}/metrics.json > ${resultsDir}/metrics.json.tmp && \
     mv ${resultsDir}/metrics.json.tmp ${resultsDir}/metrics.json
 
+  # Calculate the scenario
+  local scenario=$(jq -r '.config.repo.scenario // ""' metrics.json)
+  local filenameSuffix="latest.json"
+
+  if [[ -n "$scenario" ]]; then
+    filenameSuffix="latest-${scenario}.json"
+  fi
+
   # Copy the metrics.json to latest
-  cp -f ${resultsDir}/metrics.json ${jobResultsDir}/results-latest.json
-  cp -f ${resultsDir}/metrics.json results/${jobName}-latest.json
+  cp -f ${resultsDir}/metrics.json ${jobResultsDir}/results-${filenameSuffix}
+  cp -f ${resultsDir}/metrics.json results/${jobName}-${filenameSuffix}
 
   # Sanitize the results
   sanitize_results


### PR DESCRIPTION
When copying the `metrics.json` to `latest`, also put the scenario name in the filename.