### PR TITLE
Make `pg_isready` use same connection with applications

### DIFF
--- a/scripts/infra.sh
+++ b/scripts/infra.sh
@@ -83,7 +83,7 @@ start_postgres() {
   echo "PostgreSQL DB process: $pid"
 
   echo "Waiting for PostgreSQL to be ready..."
-  timeout 90s bash -c "until ${engine} exec $DB_CONTAINER_NAME pg_isready ; do sleep 5 ; done" || {
+  timeout 90s bash -c "until ${engine} exec $DB_CONTAINER_NAME pg_isready -h localhost -U fruits; do sleep 5 ; done" || {
     echo "Error: PostgreSQL failed to become ready"
     exit 1
   }


### PR DESCRIPTION
Since applications are using `jdbc:postgresql://localhost:5432/fruits` to connect to the database, `pg_isready` should do the same.

Adding `-h localhost` makes `pg_isready` use TCP/IP instead of unix sockets.

Adding `-U fruits` ensures that the database is ready to accept connections from the `fruits` user/role.

I have noticed that without these flags time to first response is sometimes slower (by ~1s).

Inspired by https://stackoverflow.com/a/77582897/1119431
