### PR TITLE
Spring apps not exposing prometheus endpoint

### DIFF
--- a/springboot3/pom.xml
+++ b/springboot3/pom.xml
@@ -34,6 +34,16 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-java21</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>

--- a/springboot3/src/main/resources/application.yml
+++ b/springboot3/src/main/resources/application.yml
@@ -27,6 +27,15 @@ spring:
         # see https://github.com/quarkusio/spring-quarkus-perf-comparison/pull/114
         default_batch_fetch_size: 16
 
+# Turn on prometheus actuator endpoint
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - prometheus
+
 # In order to remove errors and allow the Spring application to handle the load without errors
 # See https://github.com/quarkusio/spring-quarkus-perf-comparison/issues/60#issuecomment-3724614394
 # for a conversation about why this setting is set this way

--- a/springboot4/pom.xml
+++ b/springboot4/pom.xml
@@ -35,6 +35,16 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-java21</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>

--- a/springboot4/src/main/resources/application.yml
+++ b/springboot4/src/main/resources/application.yml
@@ -27,6 +27,15 @@ spring:
         # see https://github.com/quarkusio/spring-quarkus-perf-comparison/pull/114
         default_batch_fetch_size: 16
 
+# Turn on prometheus actuator endpoint
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - prometheus
+
 # In order to remove errors and allow the Spring application to handle the load without errors
 # See https://github.com/quarkusio/spring-quarkus-perf-comparison/issues/60#issuecomment-3724614394
 # for a conversation about why this setting is set this way


### PR DESCRIPTION
The spring apps were not exposing the prometheus actuator endpoint wheres the Quarkus versions are.