### PR TITLE
Update default pool size to match quarkus defaults

### DIFF
--- a/springboot3/src/main/resources/application.yml
+++ b/springboot3/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     hikari:
       # @simasch: Sets the jdbc pool size to be the same that Quarkus uses
       # see https://github.com/quarkusio/spring-quarkus-perf-comparison/pull/114
-      maximum-pool-size: 20
+      maximum-pool-size: 50
   jackson:
     default-property-inclusion: non_empty
   jpa:

--- a/springboot4/src/main/resources/application.yml
+++ b/springboot4/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     hikari:
       # @simasch: Sets the jdbc pool size to be the same that Quarkus uses
       # see https://github.com/quarkusio/spring-quarkus-perf-comparison/pull/114
-      maximum-pool-size: 20
+      maximum-pool-size: 50
   jackson:
     default-property-inclusion: non_empty
   jpa:


### PR DESCRIPTION
Quarkus default jdbc pool sizes changed from 20 to 50 recently. This change mirrors that on the Spring side