### PR TITLE
Move TTFR logic inside time-to-1st-request.sh (avoid qDup overheads)

### DIFF
--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -358,21 +358,16 @@ scripts:
         - queue-download: ${{REPO_DIR}}/logs/measure-time-to-first-request-${{RUNTIME.name}}-${{ITERATION}}.log
         - script: start-test-services
         - script: sync-drop-fs-cache
-        - sh: ${{RUNTIME.runCmd}} &>${{REPO_DIR}}/logs/measure-time-to-first-request-${{RUNTIME.name}}-${{ITERATION}}.log &
-        - sh: APP_PID=$!
-        - sh: timeout 60s bash -c "taskset --cpu-list ${{config.resources.cpu.1st_request}} ${{HELPER_SCRIPTS_DIR}}/time-to-1st-request.sh ${{TARGET_URL}}"
+        - sh: timeout 60s bash -c "taskset --cpu-list ${{config.resources.cpu.1st_request}} ${{HELPER_SCRIPTS_DIR}}/time-to-1st-request.sh '${{RUNTIME.runCmd}}' '${{TARGET_URL}}' '${{REPO_DIR}}/logs/measure-time-to-first-request-${{RUNTIME.name}}-${{ITERATION}}.log'"
           then:
             - regex: Terminated
               then:
-                - sh: kill -15 $APP_PID
                 - abort: Run ${{RUNTIME.runCmd}} didn't start within allotted timeout
-            - regex: .*\D.*
+            - regex: TTFR=(?<nanoseconds>\\d+) ns
               then:
-                - sh: kill -15 $APP_PID
-                - abort: Timeout script returned a non-numeric value
+                - set-state: START_TIME ${{= ${{nanoseconds}} / 1000000 }}
               else:
-                - set-state: START_TIME
-        - sh: kill -15 $APP_PID
+                - abort: Timeout script returned invalid output
         - script: state-array-push
           with:
             array: RUN.output.results.${{RUNTIME.name}}.startup.timings

--- a/scripts/perf-lab/scripts/README.md
+++ b/scripts/perf-lab/scripts/README.md
@@ -3,22 +3,46 @@ time-to-1st-request.sh
 
 Bash script to measure the time to first request (TTFR) of an application.
 
-The script polls a URL until a HTTP 200 response is returned. The time taken from when the script starts until a HTTP 200 response is received is measured and reported to the terminal in milliseconds.
-
-Note: This script does not spawn the application. The application should be started separately (e.g., in the background or in another terminal).
-
+The script spawns the application, polls a URL using pure bash to create a TCP
+connection (via `/dev/tcp`), and reports the elapsed time until the first
+HTTP 200 response in nanoseconds. The polling loop is started **before**
+the application so there is no timing gap.
 
 Running
 =======
 
-To measure the time to first request for an application, start your application and invoke the script:
+To measure the time to first request for an application, invoke the script
+with the run command, the target URL, and a log file path:
 
 ```
-$ ./time-to-1st-request.sh "http://localhost:8080/fruits"
+$ ./time-to-1st-request.sh <RUN_CMD> <TARGET_UTL> <LOG_FILE>
 ```
 
 where:
 
-"http://localhost:8080/fruits" - the URL to test
+- `RUN_CMD`    — command to start the application (e.g., `"java -jar myapp.jar"`)
+- `TARGET_URL` — URL to poll for availability (e.g., `"http://localhost:8080/fruits"`)
+- `LOG_FILE`   — file where application stdout/stderr will be written (e.g., `"app.log"`)
 
-The script will output the time in milliseconds from when it started polling until the first successful HTTP 200 response.
+e.g.:
+```
+$ ./time-to-1st-request.sh "java -jar myapp.jar" \
+    "http://localhost:8080/fruits" \
+    "app.log"
+```
+
+> [!TIP]
+> To pin the script to a single CPU core, and the application to a different set of
+> cores, invoke it with the `taskset` command, e.g.:
+> ```
+> $ taskset -c 4 ./time-to-1st-request.sh \
+>     "taskset -c 0-3 java -jar myapp.jar" \
+>     "http://localhost:8080/fruits" \
+>     "app.log"
+> ```
+
+The script outputs the TTFR in nanoseconds to stdout in the form:
+
+```
+TTFR=<nanoseconds> ns
+```

--- a/scripts/perf-lab/scripts/time-to-1st-request.sh
+++ b/scripts/perf-lab/scripts/time-to-1st-request.sh
@@ -1,22 +1,110 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-TARGET_URL=$1
-
-function _date() {
-    current=$(date +%s%N)
-    if [ $? -ne 0 ]; then
-      current=$(gdate +%s%N)
-    fi
-    echo "$current"
+# Function to display usage information
+usage() {
+    echo "Usage: $(basename "$0") RUN_CMD TARGET_URL LOG_FILE"
+    echo ""
+    echo "Measures the time to first request (TTFR) for an application."
+    echo ""
+    echo "Arguments:"
+    echo "    RUN_CMD     Command to start the application (e.g., \"java -jar app.jar\")"
+    echo "    TARGET_URL  URL to poll for availability (e.g., \"http://localhost:8080/health\")"
+    echo "    LOG_FILE    Path to file where application logs will be written"
+    echo ""
+    echo "Example:"
+    echo "    $(basename "$0") \"java -jar myapp.jar\" \"http://localhost:8080/api\" \"app.log\""
+    echo ""
+    echo "Output:"
+    echo "    Prints TTFR in nanoseconds to stdout"
+    exit 1
 }
 
+# Validate number of arguments
+if [ "$#" -ne 3 ]; then
+    echo "Error: Invalid number of arguments (expected 3, got $#)" >&2
+    echo >&2
+    usage
+fi
+
+RUN_CMD="$1"
+TARGET_URL="$2"
+LOG_FILE="$3"
+
+# Temporary file to use for writing end timestamp
+END_TS_FILE=$(mktemp)
+
+# Parse host and port from TARGET_URL (e.g. http://localhost:8080/fruits)
+# Strip off the scheme (http://)
+URL_NO_SCHEME="${TARGET_URL#http://}"
+# Get host and port
+HOST_PORT="${URL_NO_SCHEME%%/*}"
+# Get host
+HOST="${HOST_PORT%%:*}"
+# Get port
+PORT="${HOST_PORT##*:}"
+if [ -z "$PORT" ]; then
+    PORT=80
+fi
+# Get the path by stripping off the host:port
+if [[ "$URL_NO_SCHEME" == */* ]]; then
+  URL_PATH="/${URL_NO_SCHEME#*/}"
+else
+  URL_PATH="/"
+fi
+
+# Detect the date command to use
+if date +%s%N &>/dev/null; then
+  DATE_CMD="date"
+else
+  DATE_CMD="gdate"
+fi
+
+function _date() {
+    $DATE_CMD +%s%N
+}
+
+# Start the client loop before the application so it's already polling
+(
+  while true; do
+    # Try to open a TCP connection to the target host and port and use file descriptor 3 for it
+    if exec 3<>/dev/tcp/"$HOST"/"$PORT"; then
+      # Send HTTP GET request to the server
+      if ! echo -e "GET $URL_PATH HTTP/1.0\r\nHost: $HOST\r\nConnection: close\r\n\r\n" >&3; then
+        exec 3>&-
+        continue
+      fi
+      # Read the HTTP response status line and extract the status code
+      if read -r _ status_code _ <&3; then
+        exec 3>&-
+        continue
+      fi
+      # Close the file descriptor
+      exec 3>&-
+      # If we got a 200 OK response, exit the loop
+      if [[ "$status_code" == "200" ]]; then
+        break
+      fi
+    fi
+    # Spin here and do nothing rather than waiting some arbitrary unlucky timing
+  done
+  # Record the timestamp when we successfully got a 200 response
+  _date > "$END_TS_FILE"
+) 2>/dev/null &
+CURL_PID=$!
+
+# Record start time and launch the application.
+# Redirect and exec inside the subshell so the application process
+# directly replaces the subshell, making $APP_PID its actual PID.
 ts=$(_date)
+( exec $RUN_CMD &>"$LOG_FILE" ) &
+APP_PID=$!
 
-while [[ $(curl -s -o /dev/null -w ''%{http_code}'' ${TARGET_URL}) != 200 ]]
-do
-  # Spin here and do nothing rather waiting some arbitrary unlucky timing
-  :
-done
+# Ensure cleanup on exit (e.g. on timeout)
+trap "kill -15 $APP_PID $CURL_PID 2>/dev/null; wait $APP_PID 2>/dev/null || true; rm -f $END_TS_FILE" EXIT
 
-TTFR=$((($(_date) - ts)/1000000))
-echo "${TTFR}"
+# Wait for the client loop to get a successful response
+wait $CURL_PID 2>/dev/null || true
+
+TTFR=$(($(cat "$END_TS_FILE") - ts))
+echo "TTFR=${TTFR} ns"


### PR DESCRIPTION
ootb port of #317 

1. Start the client loop before starting the application
2. Replace curl with pure bash
3. Detect date/gdate at startup of script instead of each call
4. Fix parsing of bash script output in qDup
5. Add barrier before measuring performance of successfull requests

(cherry picked from commit db4c198b2f930e62df9f517b068b6cee3fc7df8e)
