### PR TITLE
Fix logic for reading HTTP response status code in time-to-1st-request.sh

### DIFF
--- a/scripts/perf-lab/scripts/time-to-1st-request.sh
+++ b/scripts/perf-lab/scripts/time-to-1st-request.sh
@@ -75,7 +75,7 @@ function _date() {
         continue
       fi
       # Read the HTTP response status line and extract the status code
-      if read -r _ status_code _ <&3; then
+      if ! read -r _ status_code _ <&3; then
         exec 3>&-
         continue
       fi


### PR DESCRIPTION
`time-to-1st-request.sh` was not the same on the ootb branch