### PR TITLE
[OOTB] Add unit configuration for benchmarking metrics in perf-lab

### DIFF
--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -11,7 +11,7 @@ states:
   config.units.rss.firstRequest: MiB
   config.units.rss.load: MiB
   config.units.load.throughput: tps
-  config.units.load.throughputDensity: req / sec per Mib
+  config.units.load.throughputDensity: tps per MiB
   config.units.load.errors.connectionErrors: absolute number
   config.units.load.errors.requestTimeouts: absolute number
 


### PR DESCRIPTION
`ootb` variant of #347 

Defined units for various performance metrics such as timings, memory usage, throughput, and errors in `main.yml`. This improves clarity and consistency across benchmarking outputs.

Fixes #289