### PR TITLE
Add workflow to sync changes between branches

### DIFF
--- a/.github/workflows/syncbot.yml
+++ b/.github/workflows/syncbot.yml
@@ -2,16 +2,9 @@ name: Branch sync
 
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
     branches:
       - main
       - ootb
-    paths-ignore:
-      - '**/application.yml'
 
 jobs:
   prep-changes:


### PR DESCRIPTION
As discussed, I've made a first pass at an automatic branch syncer. 

It will run when PRs are created or updated, since that made it easier to identify the commits. It will cherry-pick, and create a new PR. If the cherry-pick doesn't work, it will comment. It should handle repeated runs for the same PR. 

If the change is to `application.yml` I decided it's unlikely to be syncable, so the workflow doesn't run (but would it be better to run and comment, in that case?)

It cannot really be tested, except by merging (doh). But I'm hoping if it goes wrong, very little harm will be done, other than churn on the workflow file.

Once this is working, I think I have an idea how to adapt it to keep the compatibility and virtual threads projects in sync with changes too. 