### PR TITLE
Catch build failures when container runtime can't be found

### DIFF
--- a/scripts/perf-lab/helpers/container-runtime.yml
+++ b/scripts/perf-lab/helpers/container-runtime.yml
@@ -1,0 +1,45 @@
+name: Container runtime related scripts
+scripts:
+  ensure-container-runtime:
+    # Bootstrap testcontainers to check for container runtime availability
+    - sh: jbang ${{HELPER_SCRIPTS_DIR}}/check_testcontainers.java
+      then:
+        - regex: "Container runtime not found"
+          then:
+            # Testcontainers couldn't load - check if podman is available
+            - sh: command -v podman || true
+              then:
+                # Podman is available
+                - regex: "podman"
+                  then:
+                    # Try enabling the podman socket
+                    - script: enable-podman-socket
+
+                    # Try to bootstrap testcontainers again
+                    - sh: jbang ${{HELPER_SCRIPTS_DIR}}/check_testcontainers.java
+                      then:
+                        - regex: "Container runtime not found"
+                          then:
+                            - abort: Cannot determine container runtime environment after enabling podman socket
+
+                        - regex: "Container runtime is available"
+                          then:
+                            - log: Container runtime is available!!!!
+                  # Podman is not available
+                  else:
+                    - abort: Cannot determine container runtime environment - podman not available
+
+        - regex: "Container runtime is available"
+          then:
+            - log: Container runtime is available!
+
+  enable-podman-socket:
+    - script: enable-podman-socket-${{os}}
+
+  enable-podman-socket-linux:
+    - sh: systemctl --user enable --now podman.socket
+    - sh: export TESTCONTAINERS_DOCKER_CLIENT_STRATEGY=org.testcontainers.dockerclient.RootlessDockerClientProviderStrategy
+    - sh: export DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock
+
+  enable-podman-socket-macos:
+    - sh: export DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock

--- a/scripts/perf-lab/helpers/os.yml
+++ b/scripts/perf-lab/helpers/os.yml
@@ -116,7 +116,7 @@ scripts:
     - sh: sudo purge
 
   sync-drop-fs-cache:
-    - read-state: ${{DROP_OS_FILESYSTEM_CACHES:false}}
+    - read-state: ${{config.run.dropOsFilesystemCaches:false}}
       then:
         - regex: true
           then:

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -32,6 +32,8 @@ states:
   config.springboot3.native_build_options:
   config.springboot4.native_build_options:
 
+  config.run.dropOsFilesystemCaches: false
+
   config.resources.cpu.app: 0-3
   config.resources.cpu.db: 4-6
   config.resources.cpu.load_generator: 7-9
@@ -52,7 +54,6 @@ states:
   MONITOR_CMD_PREFIX: taskset --cpu-list ${{config.resources.cpu.monitor}}
   RUN.WRK_BIN: ${{LOAD_GEN_CMD_PREFIX}} jbang -R -XX:+UseNUMA wrk@hyperfoil
 
-  DROP_OS_FILESYSTEM_CACHES:
   PAUSE_TIME: 5
   PROFILER_JVM_ARGS:
   BASE_JAVA_CMD: ${{APP_CMD_PREFIX}} java ${{config.jvm.memory}} ${{config.jvm.args}} ${{PROFILER_JVM_ARGS}}
@@ -279,7 +280,16 @@ scripts:
   run-build:
     - script: start-test-services
     - sh: ${{BUILD_CMD}}
+      watch:
+        - regex: "BUILD FAILURE"
+          then:
+            - set-state: BUILD_FAILED true
     - script: stop-test-services
+    - read-state: ${{BUILD_FAILED}}
+      then:
+        - regex: "true"
+          then:
+            - abort: Build failed
 
   update-spring-boot-version:
     - script: check-dependency-exists
@@ -359,6 +369,11 @@ scripts:
         - script: sync-drop-fs-cache
         - sh: /usr/bin/time -p sh -c '${{RUNTIME.buildCmd}}' 2>&1 >${{REPO_DIR}}/logs/build-times-${{RUNTIME.name}}-${{ITERATION}}.log | grep real | awk '{print $2}'
         - set-state: BUILD_TIME
+        - sh: cat ${{REPO_DIR}}/logs/build-times-${{RUNTIME.name}}-${{ITERATION}}.log
+          then:
+            - regex: "BUILD FAILURE"
+              then:
+                - abort: Build failed for ${{RUNTIME.name}} iteration ${{ITERATION}}. Check ${{REPO_DIR}}/logs/build-times-${{RUNTIME.name}}-${{ITERATION}}.log for details.
         - script: state-array-push
           with:
             array: RUN.output.results.${{RUNTIME.name}}.build.timings
@@ -727,6 +742,7 @@ roles:
       - config-env
       - ensure-requirements
       - clone-repo
+      - ensure-container-runtime
       - capture-repo-info
       - stop-test-services
       - start-timestamp

--- a/scripts/perf-lab/run-benchmarks.sh
+++ b/scripts/perf-lab/run-benchmarks.sh
@@ -286,6 +286,7 @@ ${JBANG_CMD} io.hyperfoil.tools:qDup:0.10.8 \
     -S config.repo.scenario=${SCENARIO} \
     -S config.run.description="${DESCRIPTION}" \
     -S config.run.identifier="${RUN_IDENTIFIER}" \
+    -S config.run.dropOsFilesystemCaches=${DROP_OS_FILESYSTEM_CACHES} \
     -S env.run.host.user=${USER} \
     -S env.run.host.target=${target} \
     -S env.run.host.name=${HOST} \
@@ -293,8 +294,7 @@ ${JBANG_CMD} io.hyperfoil.tools:qDup:0.10.8 \
     -S PROJ_REPO_NAME="$(basename ${SCM_REPO_URL} .git)" \
     -S RUNTIMES="$(make_json_array $RUNTIMES)" \
     -S PAUSE_TIME=${WAIT_TIME} \
-    -S TESTS="$(make_json_array $TESTS_TO_RUN)" \
-    -S DROP_OS_FILESYSTEM_CACHES=${DROP_OS_FILESYSTEM_CACHES}
+    -S TESTS="$(make_json_array $TESTS_TO_RUN)"
 }
 
 # Only run main logic when executed directly (not when sourced)

--- a/scripts/perf-lab/scripts/check_testcontainers.java
+++ b/scripts/perf-lab/scripts/check_testcontainers.java
@@ -1,0 +1,16 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS org.testcontainers:testcontainers:2.0.4
+//DEPS org.slf4j:slf4j-simple:2.0.17
+
+import org.testcontainers.DockerClientFactory;
+
+public class check_testcontainers {
+    public static void main(String[] args) throws Exception {
+        if (DockerClientFactory.instance().isDockerAvailable()) {
+            System.out.println("Container runtime is available");
+        }
+        else {
+            throw new RuntimeException("Container runtime not found!");
+        }
+    }
+}


### PR DESCRIPTION
With the addition of the leyden things we were starting to see errors due to testcontainers not being able to find the container environment.

Added some error handling:
1. When the script first starts up, detect whether or not testcontainers can successfully run (see `scripts/perf-lab/helpers/container-runtime.yml`).

    - I did it this way because I didn't want to alter the state of the host running the scripts if I didn't have to.

2. Run a simple JBang script (see `scripts/perf-lab/scripts/check_testcontainers.java`) to check if the container runtime is available

```java
///usr/bin/env jbang "$0" "$@" ; exit $?
//DEPS org.testcontainers:testcontainers:2.0.4
//DEPS org.slf4j:slf4j-simple:2.0.17

import org.testcontainers.DockerClientFactory;

public class check_testcontainers {
    public static void main(String[] args) throws Exception {
        if (DockerClientFactory.instance().isDockerAvailable()) {
            System.out.println("Container runtime is available");
        }
        else {
            throw new RuntimeException("Container runtime not found!");
        }
    }
}
```

3. If not and the environment is using podman, try to set testcontainers to respect the `RootlessDockerClientProviderStrategy`

If after all that a container runtime still can't be found, abort the job with a clear message.

Fixes #356 
Fixes #249