### PR TITLE
[OOTB] Add syncjfr profiler option

### DIFF
--- a/scripts/perf-lab/helpers/requirements.yml
+++ b/scripts/perf-lab/helpers/requirements.yml
@@ -11,7 +11,7 @@ scripts:
   ensure-jvm-opts:
     - read-state: config.profiler.name
       then:
-        - regex: jfr|flamegraph
+        - regex: ^(jfr|flamegraph)$
           then:
             - set-state: PROFILER_JVM_ARGS -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints
 

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -40,7 +40,7 @@ states:
   config.resources.cpu.1st_request: 10
   config.resources.cpu.monitor: 11
 
-  config.profiler.name: none #jfr flamegraph
+  config.profiler.name: none #jfr syncjfr flamegraph
   config.profiler.events: cpu
 
   config.repo.branch: main
@@ -528,7 +528,16 @@ scripts:
         - script: sync-drop-fs-cache
         - set-signal: LOAD_STEADY_STATE_START 1
         - set-signal: LOG_REGEX_REACHED 1
-        - sh: ${{RUNTIME.runCmd}} &>${{LOG_FILE}} &
+        - read-state: ${{config.profiler.name}}
+          then:
+            - regex: "^syncjfr$"
+              then:
+                - queue-download: ${{REPO_DIR}}/logs/jfr.${{RUNTIME.name}}-${{ITERATION}}.jfr
+                - sh: echo "${{RUNTIME.runCmd}}" | sed 's#-jar#-XX:StartFlightRecording=filename=${{REPO_DIR}}/logs/jfr.${{RUNTIME.name}}-${{ITERATION}}.jfr,settings=profile,dumponexit=true -jar#'
+                - set-state: SYNCJFR_RUN_CMD
+                - sh: ${{SYNCJFR_RUN_CMD}} &>${{LOG_FILE}} &
+              else:
+                - sh: ${{RUNTIME.runCmd}} &>${{LOG_FILE}} &
         - sh: PID=$!
         - sh: echo $PID
         - set-state: JVM_PID
@@ -541,7 +550,7 @@ scripts:
         - log: JVM_PID = ${{JVM_PID}}
         - read-state: ${{config.profiler.name}}
           then:
-            - regex: "jfr|flamegraph"
+            - regex: "^(jfr|flamegraph)$"
               then:
                 - script: async-profiler-install
                 - script: async-profiler-configure

--- a/scripts/perf-lab/run-benchmarks.sh
+++ b/scripts/perf-lab/run-benchmarks.sh
@@ -60,8 +60,9 @@ help() {
   echo "  --native-spring4-build-options <NATIVE_SPRING4_OPTS>    Native build options to be passed to Spring 4.x native build process"
   echo "  --output-dir <OUTPUT_DIR>                               The directory containing the run output"
   echo "                                                              Default: ${OUTPUT_DIR}"
-  echo "  --profiler <PROFILER>                                   Enable profiling with async profiler"
-  echo "                                                              Accepted values: none, jfr, flamegraph"
+  echo "  --profiler <PROFILER>                                   Enable profiling"
+  echo "                                                              Accepted values: none, jfr, syncjfr, flamegraph"
+  echo "                                                              jfr/flamegraph use async profiler, syncjfr uses JVM sync profiler"
   echo "                                                              Default: ${PROFILER}"
   echo "  --quarkus-build-config-args <QUARKUS_BUILD_CONFIG_ARGS> Quarkus app configuration properties fixed at build time"
   echo "  --quarkus-version <QUARKUS_VERSION>                     The Quarkus version to use"
@@ -432,10 +433,10 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         ;;
 
       --profiler)
-        if [[ "$2" =~ ^(none|jfr|flamegraph)$ ]]; then
+        if [[ "$2" =~ ^(none|jfr|syncjfr|flamegraph)$ ]]; then
           PROFILER="$2"
         else
-          echo "!! [ERROR] --profiler option must be one of (none, jfr, flamegraph)!!"
+          echo "!! [ERROR] --profiler option must be one of (none, jfr, syncjfr, flamegraph)!!"
           exit_abnormal
         fi
         shift 2


### PR DESCRIPTION
OOTB variant of #378 

## Summary
- Adds a new `--profiler syncjfr` option that uses the JVM's built-in sync profiler via `-XX:StartFlightRecording` instead of async-profiler
- Injects JFR args into the run command by parsing `RUNTIME.runCmd` and inserting flags before `-jar` using `sed`
- Anchors existing profiler regexes to `^(jfr|flamegraph)$` to prevent `syncjfr` from inadvertently matching `jfr`

Cherry-pick of #378 onto `ootb` branch.

Fixes #374

## Test plan
- [ ] Run `./scripts/perf-lab/run-benchmarks.sh --help` and verify `syncjfr` appears in accepted values
- [ ] Run with `--profiler syncjfr` and verify it's accepted
- [ ] Run with `--profiler invalid` and verify rejection with updated error message
- [ ] Full test run with `--profiler syncjfr`: verify java command includes `-XX:StartFlightRecording=...` and async-profiler is NOT started
- [ ] Full test run with `--profiler jfr`: verify async-profiler still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)