### PR TITLE
Use sudo tee for system configuration writes (#406)

### DIFF
--- a/scripts/perf-lab/helpers/async-profiler.yml
+++ b/scripts/perf-lab/helpers/async-profiler.yml
@@ -5,12 +5,8 @@ scripts:
       then:
         - regex: linux
           then:
-            - script: sudo
-              with:
-                command: sh -c "echo 1 > /proc/sys/kernel/perf_event_paranoid"
-            - script: sudo
-              with:
-                command: sh -c "echo 0 > /proc/sys/kernel/kptr_restrict"
+            - sh: echo 1 | sudo tee /proc/sys/kernel/perf_event_paranoid > /dev/null
+            - sh: echo 0 | sudo tee /proc/sys/kernel/kptr_restrict > /dev/null
 
   # downloads the latest async-profiler release to ${{BASE_DIR}}/${{ASYNC_PROFILER}}
   download-unpack-async-profiler:

--- a/scripts/perf-lab/helpers/os.yml
+++ b/scripts/perf-lab/helpers/os.yml
@@ -108,9 +108,7 @@ scripts:
     - script: install-package-${{os}}
 
   sync-drop-fs-cache-linux:
-    - script: sudo
-      with:
-        command: sh -c "echo 3 > /proc/sys/vm/drop_caches"
+    - sh: echo 3 | sudo tee /proc/sys/vm/drop_caches > /dev/null
 
   sync-drop-fs-cache-macos:
     - sh: sudo purge


### PR DESCRIPTION
Replace `sudo sh -c "echo ... >"` with `sudo tee` for writing to system configuration files. This approach is more secure and aligns with best practices for privilege escalation.

You can now bypass sudo only for those files:
jenkins ALL=(root) NOPASSWD: /usr/bin/tee /proc/sys/vm/drop_caches jenkins ALL=(root) NOPASSWD: /usr/bin/tee /proc/sys/kernel/perf_event_paranoid jenkins ALL=(root) NOPASSWD: /usr/bin/tee /proc/sys/kernel/kptr_restrict

(cherry picked from commit db600f539e6853228f84540ace95f57bf74f85b0)

`ootb` variant of #406 by @diegolovison 