### PR TITLE
Change to numactl

### DIFF
--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -49,10 +49,10 @@ states:
 
   config.num_iterations: 3
 
-  APP_CMD_PREFIX: taskset --cpu-list ${{config.resources.cpu.app}}
-  LOAD_GEN_CMD_PREFIX: taskset --cpu-list ${{config.resources.cpu.load_generator}}
-  MONITOR_CMD_PREFIX: taskset --cpu-list ${{config.resources.cpu.monitor}}
-  RUN.WRK_BIN: ${{LOAD_GEN_CMD_PREFIX}} jbang -R -XX:+UseNUMA wrk@hyperfoil
+  APP_CMD_PREFIX: numactl --membind=0 --physcpubind=${{config.resources.cpu.app}}
+  LOAD_GEN_CMD_PREFIX: numactl --membind=0 --physcpubind=${{config.resources.cpu.load_generator}}
+  MONITOR_CMD_PREFIX: numactl --membind=0 --physcpubind=${{config.resources.cpu.monitor}}
+  RUN.WRK_BIN: ${{LOAD_GEN_CMD_PREFIX}} jbang wrk@hyperfoil
 
   PAUSE_TIME: 5
   PROFILER_JVM_ARGS:
@@ -487,7 +487,7 @@ scripts:
         - queue-download: ${{REPO_DIR}}/logs/measure-time-to-first-request-${{RUNTIMECMD.name}}-${{ITERATION}}.log
         - script: start-test-services
         - script: sync-drop-fs-cache
-        - sh: timeout 60s bash -c "taskset --cpu-list ${{config.resources.cpu.1st_request}} ${{HELPER_SCRIPTS_DIR}}/time-to-1st-request.sh '${{RUNTIMECMD.runCmd}}' '${{TARGET_URL}}' '${{REPO_DIR}}/logs/measure-time-to-first-request-${{RUNTIMECMD.name}}-${{ITERATION}}.log'"
+        - sh: timeout 60s bash -c "numactl --membind=0 --physcpubind=${{config.resources.cpu.1st_request}} ${{HELPER_SCRIPTS_DIR}}/time-to-1st-request.sh '${{RUNTIMECMD.runCmd}}' '${{TARGET_URL}}' '${{REPO_DIR}}/logs/measure-time-to-first-request-${{RUNTIMECMD.name}}-${{ITERATION}}.log'"
           then:
             - regex: Terminated
               then:


### PR DESCRIPTION
**`taskset` limitations:**
- Only pins CPU cores
- No memory placement control
- Risk of cross-NUMA memory access penalties (2-3x slower)

**`numactl` advantages:**
- **Memory locality**: `--membind=0` ensures memory stays on same NUMA node as CPUs
- **Complete NUMA awareness**: Coordinates CPU and memory placement together
- **Consistent performance**: Eliminates NUMA-related variance between benchmark runs
- **Reproducible results**: Prevents OS from migrating memory across NUMA boundaries

Changed from `taskset --cpu-list` to `numactl --membind=0 --physcpubind=` ensures both CPU affinity and memory locality, which is critical for accurate performance comparisons between Quarkus and Spring Boot applications. This eliminates a major source of measurement noise in multi-socket systems.

Found because of:

**load-test-quarkus3-jvm-0.log**
``` 
[0.020s][warning][os] NUMA support disabled: The process memory and cpu node configuration does not match
__  ____  __  _____   ___  __ ____  ______ 
 --/ __ \/ / / / _ | / _ \/ //_/ / / / __/ 
 -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \   
--\___\_\____/_/ |_/_/|_/_/|_|\____/___/   
``` 

**load-test-spring4-jvm-0.log**
``` 
[0.020s][warning][os] NUMA support disabled: The process memory and cpu node configuration does not match

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v4.0.5)
``` 

----------

We also removed `-XX:+UseNUMA` from the wrk JVM args, which makes sense since numactl now handles NUMA policy at the process level, making the JVM flag redundant.

Found because
``` 
Warning: The process is bound to a single NUMA node
``` 