### PR TITLE
Do not assume target branch is on the same fork as the CI

### DIFF
--- a/.github/workflows/syncbot.yml
+++ b/.github/workflows/syncbot.yml
@@ -36,6 +36,7 @@ jobs:
           
           # Get the source branch name and target branch
           SOURCE_BRANCH="${{ github.head_ref }}"
+          SOURCE_SHA="${{ github.event.pull_request.head.sha }"
           TARGET_BRANCH="${{ steps.target-branch.outputs.branch }}"
           SYNC_BRANCH="sync-${SOURCE_BRANCH}-to-${TARGET_BRANCH}"
           
@@ -55,7 +56,7 @@ jobs:
           git checkout -b $SYNC_BRANCH origin/$TARGET_BRANCH
           
           # Get all commits from the PR
-          COMMITS=$(git log --reverse --format="%H" origin/$TARGET_BRANCH..origin/$SOURCE_BRANCH)
+          COMMITS=$(git log --reverse --format="%H" origin/$TARGET_BRANCH..$SOURCE_SHA)
           
           # Cherry-pick each commit
           echo "Cherry-picking commits..."


### PR DESCRIPTION
Should fix 

```
fatal: ambiguous argument 'origin/ootb..origin/fix_415': unknown revision or path not in the working tree.
```

happening in the PR workflow for #422.