### PR TITLE
Fix syncbot cherry-pick for fork PRs

### DIFF
--- a/.github/workflows/syncbot.yml
+++ b/.github/workflows/syncbot.yml
@@ -31,8 +31,9 @@ jobs:
           git config user.name syncbot
           git config user.email github-actions@github.com
           
-          # Fetch all branches
+          # Fetch all branches and the PR head (which may be from a fork)
           git fetch origin
+          git fetch origin pull/${{ github.event.pull_request.number }}/head
           
           # Get the source branch name and target branch
           SOURCE_BRANCH="${{ github.head_ref }}"


### PR DESCRIPTION
## Summary
- Fetch the PR head ref (`refs/pull/N/head`) in the syncbot workflow before cherry-picking
- Fixes `fatal: Invalid revision range` error when the PR comes from a fork, since the head SHA isn't fetched by `git fetch origin` alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)