### PR TITLE
Skip empty cherry-picks in syncbot

### DIFF
--- a/.github/workflows/syncbot.yml
+++ b/.github/workflows/syncbot.yml
@@ -64,10 +64,16 @@ jobs:
           for commit in $COMMITS; do
             echo "Cherry-picking $commit"
             git cherry-pick $commit || {
-              echo "Cherry-pick failed for $commit"
-              git cherry-pick --abort
-              echo "cherry_pick_failed=true" >> $GITHUB_OUTPUT
-              exit 1
+              # If the cherry-pick is empty (change already exists on target), skip it
+              if git diff --cached --quiet; then
+                echo "Cherry-pick of $commit is empty (already applied), skipping"
+                git cherry-pick --skip
+              else
+                echo "Cherry-pick failed for $commit"
+                git cherry-pick --abort
+                echo "cherry_pick_failed=true" >> $GITHUB_OUTPUT
+                exit 1
+              fi
             }
           done
           


### PR DESCRIPTION
## Summary
- When syncing a PR, if a commit has already been applied to the target branch, the cherry-pick produces an empty result and the workflow fails
- Detect empty cherry-picks via `git diff --cached --quiet` and skip them instead of aborting the entire sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)