### PR TITLE
Fix syncbot 403 by granting write permissions

### DIFF
--- a/.github/workflows/syncbot.yml
+++ b/.github/workflows/syncbot.yml
@@ -6,6 +6,10 @@ on:
       - main
       - ootb
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   prep-changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION

- Grant explicit `contents: write` and `pull-requests: write` permissions to the syncbot workflow
- The default `GITHUB_TOKEN` for `pull_request` events only has read access, causing a 403 when pushing the sync branch
- Also includes prior fixes for conflict handling, empty cherry-picks, and fork PR support


🤖 Generated with [Claude Code](https://claude.com/claude-code)