### PR TITLE
Fix syncbot permissions for fork PRs by using `pull_request_target`

### DIFF
--- a/.github/workflows/syncbot.yml
+++ b/.github/workflows/syncbot.yml
@@ -1,7 +1,7 @@
 name: Branch sync
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - ootb


### PR DESCRIPTION
@edeandrea, this is what I was thinking of when I thought we'd only need one copy of the script. But I've just checked and although `pull_request_target` runs in the target repo, not the fork, it runs in the target branch, not `main`. So I agree we will need two copies. :)

- Switch from `pull_request` to `pull_request_target` so the workflow runs in the base repo context, giving the `GITHUB_TOKEN` write access even for fork PRs
- Add explicit `contents: write` and `pull-requests: write` permissions
- Also includes prior fixes for conflict handling, empty cherry-picks, and fork PR support

## Context
The syncbot was failing with a 403 when pushing the sync branch because `pull_request` events from forks always get a read-only `GITHUB_TOKEN`, regardless of any `permissions` block.



🤖 Generated with [Claude Code](https://claude.com/claude-code)