### PR TITLE
Improve job name in syncbot CI

### DIFF
--- a/.github/workflows/syncbot.yml
+++ b/.github/workflows/syncbot.yml
@@ -11,7 +11,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  prep-changes:
+  mirror-changes:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Raising this partly because I don't like the name of the job, but mostly because I think trying to mirror a change in this file will be carnage, and I want to see in what way the syncbot dies.