### PR TITLE
Gate CI on sync PRs to require committer authorship or approval

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - labeled
     branches:
       - main
       - ootb
@@ -33,7 +34,60 @@ defaults:
     shell: bash
 
 jobs:
+  ci-gate:
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
+    steps:
+      - name: Check CI authorization for sync PRs
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Always allow non-PR events (push, workflow_dispatch)
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Always allow non-sync PRs
+          IS_SYNC="${{ contains(github.event.pull_request.labels.*.name, 'sync') }}"
+          if [[ "$IS_SYNC" != "true" ]]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Allow sync PRs with ci-approved label
+          IS_APPROVED="${{ contains(github.event.pull_request.labels.*.name, 'ci-approved') }}"
+          if [[ "$IS_APPROVED" == "true" ]]; then
+            echo "CI approved via label"
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Check if the original commit author has write access
+          AUTHOR=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits --jq '.[0].author.login')
+          echo "Commit author: $AUTHOR"
+
+          if [[ -z "$AUTHOR" || "$AUTHOR" == "null" ]]; then
+            echo "Could not determine commit author, blocking CI. Add 'ci-approved' label to override."
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PERM=$(gh api repos/${{ github.repository }}/collaborators/$AUTHOR/permission --jq '.permission')
+          echo "Permission level: $PERM"
+
+          if [[ "$PERM" == "admin" || "$PERM" == "write" || "$PERM" == "maintain" ]]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Author $AUTHOR does not have write access. Add 'ci-approved' label to override."
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   script-tests:
+    needs: ci-gate
+    if: needs.ci-gate.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     name: "Script unit tests"
     steps:
@@ -44,6 +98,8 @@ jobs:
         run: ./run-benchmarks-tests.sh
 
   jvm-build-test:
+    needs: ci-gate
+    if: needs.ci-gate.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- Cherry-pick of d057394 from main to ootb
- Adds a ci-gate job that checks the original commit author's repo permissions and blocks CI unless they have write access or the `ci-approved` label is added manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)