### PR TITLE
[OOTB] Ignore Dependabot bot in syncbot workflow

### DIFF
--- a/.github/workflows/syncbot.yml
+++ b/.github/workflows/syncbot.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   mirror-changes:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Adds `if: github.actor != 'dependabot[bot]'` condition to the syncbot workflow's `mirror-changes` job
- Prevents syncbot from attempting to sync Dependabot PRs, since dependency versions differ between `main` and `ootb` branches

Counterpart of #461 for the `ootb` branch.

Fixes #460