### PR TITLE
Upgrade to qDup 0.11.0

### DIFF
--- a/scripts/perf-lab/helpers/sdkman.yml
+++ b/scripts/perf-lab/helpers/sdkman.yml
@@ -5,7 +5,8 @@ scripts:
     - regex: "no sdk in"
       else:
         - sh: whoami
-        - regex: (?<me>.*)
+          then:
+            - regex: (?<me>.*)
         - sh: "[[ -d /home/${{me}}/.sdkman ]] && rm -rf /home/${{me}}/.sdkman"
         - sh: sed -i 's/#THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!.*//g' /home/${{me}}/.bashrc
         - sh: sed -i 's/export SDKMAN_DIR=.*//g' /home/${{me}}/.bashrc

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -429,7 +429,8 @@ scripts:
             - regex: native
               then:
                 - sh: "sed -n 's/.*Peak RSS: \\([0-9.]*\\)\\(GB\\|GiB\\).*/\\1/p' ${{REPO_DIR}}/logs/build-times-${{RUNTIMECMD.name}}-${{ITERATION}}.log"
-                - set-state: NATIVE_BUILD_RSS
+                  then:
+                    - set-state: NATIVE_BUILD_RSS
                 - script: state-array-push
                   with:
                     array: RUN.output.results.${{RUNTIMECMD.name}}.build.native.rss
@@ -452,31 +453,38 @@ scripts:
             # The following metrics should be the same in all test iterations, so just pick the 1st
             # Capture the binary size
             - sh: "sed -n 's/^[[:space:]]*\\([0-9.]*\\)\\(MB\\|MiB\\) in total image size.*/\\1/p' ${{REPO_DIR}}/logs/build-times-${{RUNTIMECMD.name}}-0.log"
-            - set-state: RUN.output.results.${{RUNTIMECMD.name}}.build.native.binarySize
+              then:
+                - set-state: RUN.output.results.${{RUNTIMECMD.name}}.build.native.binarySize
 
             # Capture the number of classes
             - sh: "cat ${{REPO_DIR}}/logs/build-times-${{RUNTIMECMD.name}}-0.log | grep \"types.*fields.*methods found reachable\" | awk '{print $1}'"
-            - set-state: RUN.output.results.${{RUNTIMECMD.name}}.build.classCount
+              then:
+                - set-state: RUN.output.results.${{RUNTIMECMD.name}}.build.classCount
 
             # Capture the number of fields
             - sh: "cat ${{REPO_DIR}}/logs/build-times-${{RUNTIMECMD.name}}-0.log | grep \"types.*fields.*methods found reachable\" | awk '{print $3}'"
-            - set-state: RUN.output.results.${{RUNTIMECMD.name}}.build.fieldCount
+              then:
+                - set-state: RUN.output.results.${{RUNTIMECMD.name}}.build.fieldCount
 
             # Capture the number of methods
             - sh: "cat ${{REPO_DIR}}/logs/build-times-${{RUNTIMECMD.name}}-0.log | grep \"types.*fields.*methods found reachable\" | awk '{print $6}'"
-            - set-state: RUN.output.results.${{RUNTIMECMD.name}}.build.methodCount
+              then:
+                - set-state: RUN.output.results.${{RUNTIMECMD.name}}.build.methodCount
 
             # Capture the number of classes registered for reflection
             - sh: "cat ${{REPO_DIR}}/logs/build-times-${{RUNTIMECMD.name}}-0.log | grep \"types.*fields.*methods registered for reflection\" | awk '{print $1}'"
-            - set-state: RUN.output.results.${{RUNTIMECMD.name}}.build.reflectionClassCount
+              then:
+                - set-state: RUN.output.results.${{RUNTIMECMD.name}}.build.reflectionClassCount
 
             # Capture the number of fields registered for reflection
             - sh: "cat ${{REPO_DIR}}/logs/build-times-${{RUNTIMECMD.name}}-0.log | grep \"types.*fields.*methods registered for reflection\" | awk '{print $3}'"
-            - set-state: RUN.output.results.${{RUNTIMECMD.name}}.build.reflectionFieldCount
+              then:
+                - set-state: RUN.output.results.${{RUNTIMECMD.name}}.build.reflectionFieldCount
 
             # Capture the number of methods registered for reflection
             - sh: "cat ${{REPO_DIR}}/logs/build-times-${{RUNTIMECMD.name}}-0.log | grep \"types.*fields.*methods registered for reflection\" | awk '{print $6}'"
-            - set-state: RUN.output.results.${{RUNTIMECMD.name}}.build.reflectionMethodCount
+              then:
+                - set-state: RUN.output.results.${{RUNTIMECMD.name}}.build.reflectionMethodCount
 
   measure-time-to-first-request:
     - log: Measuring Time to first request
@@ -573,7 +581,8 @@ scripts:
               then:
                 - queue-download: ${{REPO_DIR}}/logs/jfr.${{RUNTIMECMD.name}}-${{ITERATION}}.jfr
                 - sh: echo "${{RUNTIMECMD.runCmd}}" | sed 's#-jar#-XX:StartFlightRecording=filename=${{REPO_DIR}}/logs/jfr.${{RUNTIMECMD.name}}-${{ITERATION}}.jfr,settings=profile,dumponexit=true -jar#'
-                - set-state: SYNCJFR_RUN_CMD
+                  then:
+                    - set-state: SYNCJFR_RUN_CMD
                 - sh: ${{SYNCJFR_RUN_CMD}} &>${{LOG_FILE}} &
               else:
                 - sh: ${{RUNTIMECMD.runCmd}} &>${{LOG_FILE}} &

--- a/scripts/perf-lab/run-benchmarks.sh
+++ b/scripts/perf-lab/run-benchmarks.sh
@@ -260,7 +260,7 @@ run_benchmarks() {
 
 #  jbang qDup@hyperfoil --trace="target" \
 
-${JBANG_CMD} io.hyperfoil.tools:qDup:0.10.8 \
+${JBANG_CMD} io.hyperfoil.tools:qDup:0.11.0 \
     -B ${OUTPUT_DIR} \
     -ix \
     ${EXTRA_QDUP_ARGS} \


### PR DESCRIPTION
## Summary

- Upgrade qDup from 0.10.8 to 0.11.0
- Adapt qDup scripts to the [breaking change in sibling command output behavior](https://github.com/Hyperfoil/qDup/releases/tag/0.11.0): in 0.11.0, sibling commands under `then:` and `else:` blocks receive input from the parent command rather than from the previous sibling
- Nest `set-state`/`regex` commands that depend on a preceding sibling's output under that sibling via `then:` to preserve correct data flow

### Files changed
- `scripts/perf-lab/run-benchmarks.sh` — version bump
- `scripts/perf-lab/main.yml` — 9 nesting fixes in `measure-build-times` and `run-load-test`
- `scripts/perf-lab/helpers/sdkman.yml` — 1 nesting fix in `sdkman-uninstall`

## Test plan
- [ ] Run benchmarks with qDup 0.11.0 and verify all metrics are captured correctly
- [ ] Verify native build metrics (binarySize, classCount, fieldCount, methodCount, reflection counts) are populated
- [ ] Verify syncjfr profiler mode works correctly
- [ ] Verify sdkman uninstall works on a system with SDKMAN installed

Fixes #252