### PR TITLE
Add energy measurement support (RAPL + iDRAC)

### DIFF
--- a/scripts/perf-lab/helpers/energy.yml
+++ b/scripts/perf-lab/helpers/energy.yml
@@ -17,6 +17,35 @@ scripts:
                   with:
                     array: RUN.svrPwr
                     value: ${{watts}}
+  idrac-login:
+    - sh: IDRAC_HOST="${{idrac}}"
+    - sh: IDRAC_USER="${{idrac_user:root}}"
+    - sh: IDRAC_PWD="${{password}}"
+    - sh: REAL_RACADM=$(which racadm)
+    - sh: 'racadm() { "$REAL_RACADM" -r "$IDRAC_HOST" -u "$IDRAC_USER" -p "$IDRAC_PWD" --nocertwarn "$@"; }'
+    - sh: racadm getsysinfo
+      then:
+        - regex: "System Model"
+          then:
+            - log: Connected to iDRAC at ${{idrac}}
+          else:
+            - abort: "Failed to connect to iDRAC at ${{idrac}}. Verify hostname and credentials."
+
+  validate-idrac:
+    - read-state: ${{config.energy.idrac}}
+      then:
+        - regex: "enabled"
+          then:
+            - sh: "which racadm &>/dev/null && echo RACADM_FOUND || echo RACADM_MISSING"
+              then:
+                - regex: RACADM_FOUND
+                  then:
+                    - set-state: RUN.IDRAC_AVAILABLE true
+                - regex: RACADM_MISSING
+                  then:
+                    - set-state: RUN.IDRAC_AVAILABLE false
+                    - log: racadm not found on this system, skipping energy measurement via iDRAC
+
   install-rapl-plot:
     - read-state: ${{config.energy.rapl}}
       then:

--- a/scripts/perf-lab/helpers/energy.yml
+++ b/scripts/perf-lab/helpers/energy.yml
@@ -1,0 +1,42 @@
+name: Energy-related scripts
+scripts:
+  capture-system-power:
+    - script: idrac-login
+      with:
+        idrac: ${{= ${{servers}}.filter( server => { return server.hostname == "${{env.HOST}}"})[0].idrac}}
+        password: ${{idrac_pwd}}
+    - set-state: RUN.svrPwr []
+    - repeat-until: ${{COMPLETE_SIGNAL}}
+      then:
+        - sleep: 1s
+        - sh: racadm get system.Power.Realtime.Power
+          then:
+            - regex: (?<watts>\\d+) W | (?<btu>\\d+) Btu/hr
+              then:
+                - script: state-array-push
+                  with:
+                    array: RUN.svrPwr
+                    value: ${{watts}}
+  install-rapl-plot:
+    - read-state: ${{config.energy.rapl}}
+      then:
+        - regex: "enabled"
+          then:
+            - sh: "[[ -d /sys/class/powercap/intel-rapl ]] && echo RAPL_SUPPORTED || echo RAPL_UNSUPPORTED"
+              then:
+                - regex: RAPL_SUPPORTED
+                  then:
+                    - sh: "[[ -f ${{RAPL_PATH:/tmp/rapl}}/${{RAPL_EXE:rapl-plot}} ]] || echo GETRAPL;"
+                      then:
+                        - regex: GET
+                          then:
+                            - sh: mkdir -p ${{RAPL_PATH:/tmp/rapl}}
+                            - sh: cd ${{RAPL_PATH:/tmp/rapl}}
+                            - sh: git clone https://github.com/deater/uarch-configure.git
+                            - sh: cd uarch-configure/rapl-read
+                            - sh: make all
+                            - sh: cp rapl-plot ${{RAPL_PATH:/tmp/rapl}}/${{RAPL_EXE:rapl-plot}}
+                    - set-state: RUN.RAPL_BIN ${{RAPL_PATH:/tmp/rapl}}/${{RAPL_EXE:rapl-plot}}
+                - regex: RAPL_UNSUPPORTED
+                  then:
+                    - log: RAPL not available on this system, skipping energy measurement via RAPL

--- a/scripts/perf-lab/helpers/energy.yml
+++ b/scripts/perf-lab/helpers/energy.yml
@@ -107,6 +107,9 @@ scripts:
             - set-state:
                 key: ${{result_prefix}}.totalIdrac
                 value: ${{= ${{${{result_prefix}}.idrac}}.reduce((a, b) => a + b, 0) || 0 }}
+            - set-state:
+                key: ${{result_prefix}}.energyPerRequestIdrac
+                value: ${{= (${{${{result_prefix}}.idrac}}.reduce((a, b) => a + b, 0) || 0) / (${{av_throughput}} * ${{duration}} * ${{num_iterations}}) }}
     - read-state: ${{config.energy.rapl}}
       then:
         - regex: "enabled"
@@ -121,6 +124,9 @@ scripts:
                     - set-state:
                         key: ${{result_prefix}}.totalRaplDram
                         value: ${{= ${{${{result_prefix}}.raplDram}}.reduce((a, b) => a + b, 0) || 0 }}
+                    - set-state:
+                        key: ${{result_prefix}}.energyPerRequestRaplPkg
+                        value: ${{= (${{${{result_prefix}}.raplPkg}}.reduce((a, b) => a + b, 0) || 0) / (${{av_throughput}} * ${{duration}} * ${{num_iterations}}) }}
 
   install-rapl-plot:
     - read-state: ${{config.energy.rapl}}

--- a/scripts/perf-lab/helpers/energy.yml
+++ b/scripts/perf-lab/helpers/energy.yml
@@ -38,6 +38,90 @@ scripts:
                     - set-state: RUN.IDRAC_AVAILABLE false
                     - log: racadm not found on this system, skipping energy measurement via iDRAC
 
+  start-energy-capture:
+    - read-state: ${{config.energy.rapl}}
+      then:
+        - regex: "enabled"
+          then:
+            - sh: "[[ -x ${{RUN.RAPL_BIN:__NORAPL__}} ]] && echo RAPL_READY"
+              then:
+                - regex: RAPL_READY
+                  then:
+                    - script: sudo
+                      with:
+                        command: ${{RUN.RAPL_BIN}} -p > ${{RUN.OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.rapl &
+                    - sh: echo $!
+                      then:
+                        - set-state: RUN.RAPL_PID
+    - read-state: ${{RUN.IDRAC_AVAILABLE}}
+      then:
+        - regex: "true"
+          then:
+            - set-signal: ${{COMPLETE_SIGNAL}} 1
+            - script:
+                name: capture-system-power
+                async: true
+
+  stop-energy-capture:
+    - read-state: ${{RUN.IDRAC_AVAILABLE}}
+      then:
+        - regex: "true"
+          then:
+            - signal: ${{COMPLETE_SIGNAL}}
+            - sh: echo "${{RUN.svrPwr}}" > ${{RUN.OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.svrPwr
+            - set-state: IDRAC_ENERGY ${{= ${{RUN.svrPwr}}.reduce((a, b) => a + b, 0) || 0 }}
+            - script: state-array-push
+              with:
+                array: ${{result_prefix}}.idrac
+                value: ${{IDRAC_ENERGY}}
+    - read-state: ${{config.energy.rapl}}
+      then:
+        - regex: "enabled"
+          then:
+            - sh: "[[ -x ${{RUN.RAPL_BIN:__NORAPL__}} ]] && echo RAPL_READY"
+              then:
+                - regex: RAPL_READY
+                  then:
+                    - script: sudo
+                      with:
+                        command: kill ${{RUN.RAPL_PID}}
+                    - sh: sleep 1
+                    - sh: awk -F', ' '/^[^#]/{s+=$2; d+=$4} END{printf "%.2f %.2f", s, d}' ${{RUN.OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.rapl
+                      then:
+                        - regex: (?<pkg>\S+) (?<dram>\S+)
+                          then:
+                            - script: state-array-push
+                              with:
+                                array: ${{result_prefix}}.raplPkg
+                                value: ${{pkg}}
+                            - script: state-array-push
+                              with:
+                                array: ${{result_prefix}}.raplDram
+                                value: ${{dram}}
+
+  calc-energy-totals:
+    - read-state: ${{RUN.IDRAC_AVAILABLE}}
+      then:
+        - regex: "true"
+          then:
+            - set-state:
+                key: ${{result_prefix}}.totalIdrac
+                value: ${{= ${{${{result_prefix}}.idrac}}.reduce((a, b) => a + b, 0) || 0 }}
+    - read-state: ${{config.energy.rapl}}
+      then:
+        - regex: "enabled"
+          then:
+            - sh: "[[ -x ${{RUN.RAPL_BIN:__NORAPL__}} ]] && echo RAPL_READY"
+              then:
+                - regex: RAPL_READY
+                  then:
+                    - set-state:
+                        key: ${{result_prefix}}.totalRaplPkg
+                        value: ${{= ${{${{result_prefix}}.raplPkg}}.reduce((a, b) => a + b, 0) || 0 }}
+                    - set-state:
+                        key: ${{result_prefix}}.totalRaplDram
+                        value: ${{= ${{${{result_prefix}}.raplDram}}.reduce((a, b) => a + b, 0) || 0 }}
+
   install-rapl-plot:
     - read-state: ${{config.energy.rapl}}
       then:

--- a/scripts/perf-lab/helpers/energy.yml
+++ b/scripts/perf-lab/helpers/energy.yml
@@ -2,9 +2,6 @@ name: Energy-related scripts
 scripts:
   capture-system-power:
     - script: idrac-login
-      with:
-        idrac: ${{= ${{servers}}.filter( server => { return server.hostname == "${{env.HOST}}"})[0].idrac}}
-        password: ${{idrac_pwd}}
     - set-state: RUN.svrPwr []
     - repeat-until: ${{COMPLETE_SIGNAL}}
       then:
@@ -18,18 +15,13 @@ scripts:
                     array: RUN.svrPwr
                     value: ${{watts}}
   idrac-login:
-    - sh: IDRAC_HOST="${{idrac}}"
-    - sh: IDRAC_USER="${{idrac_user:root}}"
-    - sh: IDRAC_PWD="${{password}}"
-    - sh: REAL_RACADM=$(which racadm)
-    - sh: 'racadm() { "$REAL_RACADM" -r "$IDRAC_HOST" -u "$IDRAC_USER" -p "$IDRAC_PWD" --nocertwarn "$@"; }'
     - sh: racadm getsysinfo
       then:
         - regex: "System Model"
           then:
-            - log: Connected to iDRAC at ${{idrac}}
+            - log: Connected to local iDRAC
           else:
-            - abort: "Failed to connect to iDRAC at ${{idrac}}. Verify hostname and credentials."
+            - abort: "Failed to connect to local iDRAC. Is this a Dell server with racadm installed?"
 
   validate-idrac:
     - read-state: ${{config.energy.idrac}}

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -17,6 +17,8 @@ states:
   config.units.energy.idrac: J
   config.units.energy.raplPkg: J
   config.units.energy.raplDram: J
+  config.units.energy.energyPerRequestIdrac: J/req
+  config.units.energy.energyPerRequestRaplPkg: J/req
   config.units.energy.throughput: tps
 
   config.jvm.home: #/path/to/java
@@ -582,8 +584,8 @@ scripts:
         - queue-download: ${{REPO_DIR}}/logs/wrk-${{RUNTIMECMD.name}}-${{ITERATION}}.log
         - set-state: RUN.OUTPUT_DIR ${{REPO_DIR}}/logs
         - set-state: RUN.COMPLETE_SIGNAL load-test-energy-${{RUNTIMECMD.name}}-${{ITERATION}}
-        - queue-download: ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.rapl
-        - queue-download: ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.svrPwr
+        - queue-download: ${{RUN.OUTPUT_DIR}}/${{RUN.COMPLETE_SIGNAL}}.rapl
+        - queue-download: ${{RUN.OUTPUT_DIR}}/${{RUN.COMPLETE_SIGNAL}}.svrPwr
         - script: start-test-services
         - script: sync-drop-fs-cache
         - set-signal: LOAD_STEADY_STATE_START 1
@@ -726,9 +728,13 @@ scripts:
     - script: calc-energy-totals
       with:
         result_prefix: RUN.output.results.${{RUNTIMECMD.name}}.energyMaxLoad
+        av_throughput: ${{RUN.output.results.${{RUNTIMECMD.name}}.load.avThroughput}}
+        duration: 30
+        num_iterations: ${{config.num_iterations}}
 
   measure-energy-fixed-throughput:
     - log: Measuring energy at fixed throughput (${{config.energy.fixed.rate}} tps)
+    - sh: java -version
     - sh: cd ${{RUNTIMECMD.dir}}
     - set-state:
         key: APP_LOG_REGEX
@@ -744,8 +750,8 @@ scripts:
         - queue-download: ${{LOG_FILE}}
         - queue-download: ${{REPO_DIR}}/logs/wrk-energy-fixed-warmup-${{RUNTIMECMD.name}}-${{ITERATION}}.log
         - queue-download: ${{REPO_DIR}}/logs/wrk-energy-fixed-${{RUNTIMECMD.name}}-${{ITERATION}}.log
-        - queue-download: ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.rapl
-        - queue-download: ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.svrPwr
+        - queue-download: ${{RUN.OUTPUT_DIR}}/${{RUN.COMPLETE_SIGNAL}}.rapl
+        - queue-download: ${{RUN.OUTPUT_DIR}}/${{RUN.COMPLETE_SIGNAL}}.svrPwr
         - script: start-test-services
         - script: sync-drop-fs-cache
         - set-signal: LOG_REGEX_REACHED 1
@@ -753,6 +759,12 @@ scripts:
         - sh: PID=$!
         - sh: echo $PID
         - set-state: JVM_PID
+        - script: monitor-processes
+          with:
+            pid: ${{JVM_PID}}
+            log_dir: ${{REPO_DIR}}/logs
+            runtime_name: ${{RUNTIMECMD.name}}
+            iteration: ${{ITERATION}}
         - script:
             name: watch-log
             async: true
@@ -763,7 +775,7 @@ scripts:
         - sh: ${{RUN.WRK_BIN}} -t 2 -c 100 -d 30s -R ${{config.energy.fixed.rate}} --timeout 30s ${{TARGET_URL}} 2>&1 >${{REPO_DIR}}/logs/wrk-energy-fixed-warmup-${{RUNTIMECMD.name}}-${{ITERATION}}.log
         - sleep: 10s
         - script: start-energy-capture
-        - sh: ${{RUN.WRK_BIN}} -t 2 -c 100 -d ${{config.energy.fixed.duration}}s -R ${{config.energy.fixed.rate}} --timeout ${{config.energy.fixed.duration}}s ${{TARGET_URL}} > ${{REPO_DIR}}/logs/wrk-energy-fixed-${{RUNTIMECMD.name}}-${{ITERATION}}.log 2>&1 &
+        - sh: ${{RUN.WRK_BIN}} -t 2 -c 100 -d ${{config.energy.fixed.duration}}s -R ${{config.energy.fixed.rate}} --timeout 30s ${{TARGET_URL}} > ${{REPO_DIR}}/logs/wrk-energy-fixed-${{RUNTIMECMD.name}}-${{ITERATION}}.log 2>&1 &
         - sh: WRK_PID=$! && echo $WRK_PID
         - set-state: WRK_PID
         - sh: wait ${{WRK_PID}}
@@ -787,6 +799,9 @@ scripts:
     - script: calc-energy-totals
       with:
         result_prefix: RUN.output.results.${{RUNTIMECMD.name}}.energyFixedLoad
+        av_throughput: ${{RUN.output.results.${{RUNTIMECMD.name}}.energyFixedLoad.avThroughput}}
+        duration: ${{config.energy.fixed.duration}}
+        num_iterations: ${{config.num_iterations}}
 
   watch-log:
     - sh: tail -f ${{log_file}}

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -14,9 +14,9 @@ states:
   config.units.load.throughputDensity: tps per MiB
   config.units.load.errors.connectionErrors: absolute number
   config.units.load.errors.requestTimeouts: absolute number
-  config.units.energy.idrac: W
-  config.units.energy.raplPkg: W
-  config.units.energy.raplDram: W
+  config.units.energy.idrac: J
+  config.units.energy.raplPkg: J
+  config.units.energy.raplDram: J
 
   config.jvm.home: #/path/to/java
   config.jvm.version: 25.0.2-tem
@@ -47,6 +47,7 @@ states:
 
   config.energy.rapl: enabled #disabled
   config.energy.idrac: enabled #disabled
+  config.energy.rss.duration: 150
   config.profiler.name: none #jfr syncjfr flamegraph
   config.profiler.events: cpu
 
@@ -575,17 +576,18 @@ scripts:
           with:
             array: RUN.output.results.${{RUNTIMECMD.name}}.rss.firstRequest
             value: ${{= ${{FIRST_REQUEST}}/1024 }}
+        - sh: sleep ${{config.energy.rss.duration}}
         - read-state: ${{RUN.IDRAC_AVAILABLE}}
           then:
             - regex: "true"
               then:
                 - signal: ${{COMPLETE_SIGNAL}}
                 - sh: echo "${{RUN.svrPwr}}" > ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.svrPwr
-                - set-state: IDRAC_AVG_WATTS ${{= (${{RUN.svrPwr}}.reduce((a, b) => a + b, 0) / ${{RUN.svrPwr}}.length) || 0 }}
+                - set-state: IDRAC_ENERGY ${{= ${{RUN.svrPwr}}.reduce((a, b) => a + b, 0) || 0 }}
                 - script: state-array-push
                   with:
                     array: RUN.output.results.${{RUNTIMECMD.name}}.energy.idrac
-                    value: ${{IDRAC_AVG_WATTS}}
+                    value: ${{IDRAC_ENERGY}}
         - read-state: ${{config.energy.rapl}}
           then:
             - regex: "enabled"
@@ -598,7 +600,7 @@ scripts:
                           with:
                             command: kill ${{RUN.RAPL_PID}}
                         - sh: sleep 1
-                        - sh: awk -F', ' '/^[^#]/{s+=$2; d+=$4; n++} END{if(n>0) printf "%.2f %.2f", s/n, d/n; else print "0 0"}' ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.rapl
+                        - sh: awk -F', ' '/^[^#]/{s+=$2; d+=$4} END{printf "%.2f %.2f", s, d}' ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.rapl
                           then:
                             - regex: (?<pkg>\S+) (?<dram>\S+)
                               then:

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -525,20 +525,15 @@ scripts:
         var-name: RUN.output.results.${{RUNTIMECMD.name}}.startup.avStartTime
         array: RUN.output.results.${{RUNTIMECMD.name}}.startup.timings
 
-  measure-rss: # also measures energy
+  measure-rss:
     - log: Measuring RSS
     - sh: java -version
     - sh: cd ${{RUNTIMECMD.dir}}
     - for-each: ITERATION ${{=[...Array(${{config.num_iterations}}).keys()]}}
       then:
-        - set-state: RUN.OUTPUT_DIR ${{REPO_DIR}}/logs
-        - set-state: RUN.COMPLETE_SIGNAL measure-rss-${{RUNTIMECMD.name}}-${{ITERATION}}
         - queue-download: ${{REPO_DIR}}/logs/measure-rss-${{RUNTIMECMD.name}}-${{ITERATION}}.log
-        - queue-download: ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.rapl
-        - queue-download: ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.svrPwr
         - script: start-test-services
         - script: sync-drop-fs-cache
-        - script: start-energy-capture
         - sh: ${{RUNTIMECMD.runCmd}} &>${{REPO_DIR}}/logs/measure-rss-${{RUNTIMECMD.name}}-${{ITERATION}}.log &
         - sh: APP_PID=$!
         - sh: sleep ${{PAUSE_TIME}}
@@ -557,9 +552,6 @@ scripts:
           with:
             array: RUN.output.results.${{RUNTIMECMD.name}}.rss.firstRequest
             value: ${{= ${{FIRST_REQUEST}}/1024 }}
-        - script: stop-energy-capture
-          with:
-            result_prefix: RUN.output.results.${{RUNTIMECMD.name}}.energy
         - sh: kill -15 $APP_PID
         - sh: sleep ${{PAUSE_TIME}}
         - script: stop-test-services
@@ -571,9 +563,6 @@ scripts:
       with:
         var-name: RUN.output.results.${{RUNTIMECMD.name}}.rss.avFirstRequestRss
         array: RUN.output.results.${{RUNTIMECMD.name}}.rss.firstRequest
-    - script: calc-energy-totals
-      with:
-        result_prefix: RUN.output.results.${{RUNTIMECMD.name}}.energy
 
   run-load-test:
     - log: Running workload
@@ -591,6 +580,10 @@ scripts:
         - queue-download: ${{REPO_DIR}}/logs/wrk-warmup-${{RUNTIMECMD.name}}-${{ITERATION}}.log
         - queue-download: ${{LOG_FILE}}
         - queue-download: ${{REPO_DIR}}/logs/wrk-${{RUNTIMECMD.name}}-${{ITERATION}}.log
+        - set-state: RUN.OUTPUT_DIR ${{REPO_DIR}}/logs
+        - set-state: RUN.COMPLETE_SIGNAL load-test-energy-${{RUNTIMECMD.name}}-${{ITERATION}}
+        - queue-download: ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.rapl
+        - queue-download: ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.svrPwr
         - script: start-test-services
         - script: sync-drop-fs-cache
         - set-signal: LOAD_STEADY_STATE_START 1
@@ -647,6 +640,7 @@ scripts:
           then:
             - abort: unable to connect to target application
         - sleep: 30s # Wait for the app to complete warmup
+        - script: start-energy-capture
         - signal: LOAD_STEADY_STATE_START
         - sh: ${{RUN.WRK_BIN}} -t 2 -c 100 -d 30s --timeout 30s ${{TARGET_URL}} > ${{REPO_DIR}}/logs/wrk-${{RUNTIMECMD.name}}-${{ITERATION}}.log 2>&1 &
         - sh: WRK_PID=$! && echo $WRK_PID
@@ -666,6 +660,9 @@ scripts:
           with:
             array: RUN.output.results.${{RUNTIMECMD.name}}.load.throughput
             value: ${{THROUGHPUT}}
+        - script: stop-energy-capture
+          with:
+            result_prefix: RUN.output.results.${{RUNTIMECMD.name}}.energyMaxLoad
         - sh: cat ${{REPO_DIR}}/logs/wrk-${{RUNTIMECMD.name}}-${{ITERATION}}.log | grep "Socket errors:" | sed -E 's/.*connectionErrors ([0-9]+).*/\1/'
           then:
             - regex: ^$
@@ -726,64 +723,6 @@ scripts:
       with:
         var-name: RUN.output.results.${{RUNTIMECMD.name}}.load.avRequestTimeouts
         array: RUN.output.results.${{RUNTIMECMD.name}}.load.requestTimeouts
-
-  measure-energy-max-throughput:
-    - log: Measuring energy at max throughput
-    - sh: cd ${{RUNTIMECMD.dir}}
-    - set-state:
-        key: APP_LOG_REGEX
-        value: ${{RUNTIMECMD.logFileStartedRegex}}
-    - for-each: ITERATION ${{=[...Array(${{config.num_iterations}}).keys()]}}
-      then:
-        - set-state: RUN.OUTPUT_DIR ${{REPO_DIR}}/logs
-        - set-state: RUN.COMPLETE_SIGNAL energy-max-${{RUNTIMECMD.name}}-${{ITERATION}}
-        - set-state:
-            key: LOG_FILE
-            value: ${{REPO_DIR}}/logs/energy-max-${{RUNTIMECMD.name}}-${{ITERATION}}.log
-        - sh: touch ${{LOG_FILE}}
-        - queue-download: ${{LOG_FILE}}
-        - queue-download: ${{REPO_DIR}}/logs/wrk-energy-max-warmup-${{RUNTIMECMD.name}}-${{ITERATION}}.log
-        - queue-download: ${{REPO_DIR}}/logs/wrk-energy-max-${{RUNTIMECMD.name}}-${{ITERATION}}.log
-        - queue-download: ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.rapl
-        - queue-download: ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.svrPwr
-        - script: start-test-services
-        - script: sync-drop-fs-cache
-        - set-signal: LOG_REGEX_REACHED 1
-        - sh: ${{RUNTIMECMD.runCmd}} &>${{LOG_FILE}} &
-        - sh: PID=$!
-        - sh: echo $PID
-        - set-state: JVM_PID
-        - script:
-            name: watch-log
-            async: true
-          with:
-            log_file: ${{LOG_FILE}}
-            log_regex: ${{APP_LOG_REGEX}}
-        - wait-for: LOG_REGEX_REACHED
-        - sh: ${{RUN.WRK_BIN}} -t 2 -c 100 -d 2m --timeout 2m ${{TARGET_URL}} 2>&1 >${{REPO_DIR}}/logs/wrk-energy-max-warmup-${{RUNTIMECMD.name}}-${{ITERATION}}.log
-        - sleep: 30s
-        - script: start-energy-capture
-        - sh: ${{RUN.WRK_BIN}} -t 2 -c 100 -d 30s --timeout 30s ${{TARGET_URL}} > ${{REPO_DIR}}/logs/wrk-energy-max-${{RUNTIMECMD.name}}-${{ITERATION}}.log 2>&1 &
-        - sh: WRK_PID=$! && echo $WRK_PID
-        - set-state: WRK_PID
-        - sh: wait ${{WRK_PID}}
-        - sh: cat ${{REPO_DIR}}/logs/wrk-energy-max-${{RUNTIMECMD.name}}-${{ITERATION}}.log | grep "Requests/sec" | awk '{print $2}'
-          then:
-            - set-state: THROUGHPUT
-        - script: state-array-push
-          with:
-            array: RUN.output.results.${{RUNTIMECMD.name}}.energyMaxLoad.throughput
-            value: ${{THROUGHPUT}}
-        - script: stop-energy-capture
-          with:
-            result_prefix: RUN.output.results.${{RUNTIMECMD.name}}.energyMaxLoad
-        - sh: kill -15 $PID
-        - sh: sleep ${{PAUSE_TIME}}
-        - script: stop-test-services
-    - script: state-array-calc-avg
-      with:
-        var-name: RUN.output.results.${{RUNTIMECMD.name}}.energyMaxLoad.avThroughput
-        array: RUN.output.results.${{RUNTIMECMD.name}}.energyMaxLoad.throughput
     - script: calc-energy-totals
       with:
         result_prefix: RUN.output.results.${{RUNTIMECMD.name}}.energyMaxLoad

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -66,7 +66,7 @@ states:
   PAUSE_TIME: 5
   PROFILER_JVM_ARGS:
   BASE_JAVA_CMD: ${{APP_CMD_PREFIX}} java ${{config.jvm.memory}} ${{config.jvm.args}} ${{PROFILER_JVM_ARGS}}
-  TESTS : [measure-time-to-first-request, measure-rss, run-load-test]
+  TESTS : [measure-time-to-first-request, measure-rss, run-load-test, measure-energy-fixed-throughput]
   RUNTIMES: [quarkus3-jvm, quarkus3-virtual, quarkus3-native, spring3-jvm, spring3-virtual, spring3-native, spring4-jvm, spring4-virtual, spring4-native]
   TARGET_URL: http://localhost:8080/fruits
   QUARKUS-PLATFORM-ARTIFACT-ID: quarkus-bom

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -549,18 +549,14 @@ scripts:
                         - sh: echo $!
                           then:
                             - set-state: RUN.RAPL_PID
-        - read-state: ${{config.energy.idrac}}
+        - read-state: ${{RUN.IDRAC_AVAILABLE}}
           then:
-            - regex: "enabled"
+            - regex: "true"
               then:
-                - sh: "command -v racadm > /dev/null 2>&1 && echo IDRAC_READY"
-                  then:
-                    - regex: IDRAC_READY
-                      then:
-                        - set-signal: ${{COMPLETE_SIGNAL}} 1
-                        - script:
-                            name: capture-system-power
-                            async: true
+                - set-signal: ${{COMPLETE_SIGNAL}} 1
+                - script:
+                    name: capture-system-power
+                    async: true
         - sh: ${{RUNTIMECMD.runCmd}} &>${{REPO_DIR}}/logs/measure-rss-${{RUNTIMECMD.name}}-${{ITERATION}}.log &
         - sh: APP_PID=$!
         - sh: sleep ${{PAUSE_TIME}}
@@ -579,21 +575,17 @@ scripts:
           with:
             array: RUN.output.results.${{RUNTIMECMD.name}}.rss.firstRequest
             value: ${{= ${{FIRST_REQUEST}}/1024 }}
-        - read-state: ${{config.energy.idrac}}
+        - read-state: ${{RUN.IDRAC_AVAILABLE}}
           then:
-            - regex: "enabled"
+            - regex: "true"
               then:
-                - sh: "command -v racadm > /dev/null 2>&1 && echo IDRAC_READY"
-                  then:
-                    - regex: IDRAC_READY
-                      then:
-                        - signal: ${{COMPLETE_SIGNAL}}
-                        - sh: echo "${{RUN.svrPwr}}" > ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.svrPwr
-                        - set-state: IDRAC_AVG_WATTS ${{= (${{RUN.svrPwr}}.reduce((a, b) => a + b, 0) / ${{RUN.svrPwr}}.length) || 0 }}
-                        - script: state-array-push
-                          with:
-                            array: RUN.output.results.${{RUNTIMECMD.name}}.energy.idrac
-                            value: ${{IDRAC_AVG_WATTS}}
+                - signal: ${{COMPLETE_SIGNAL}}
+                - sh: echo "${{RUN.svrPwr}}" > ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.svrPwr
+                - set-state: IDRAC_AVG_WATTS ${{= (${{RUN.svrPwr}}.reduce((a, b) => a + b, 0) / ${{RUN.svrPwr}}.length) || 0 }}
+                - script: state-array-push
+                  with:
+                    array: RUN.output.results.${{RUNTIMECMD.name}}.energy.idrac
+                    value: ${{IDRAC_AVG_WATTS}}
         - read-state: ${{config.energy.rapl}}
           then:
             - regex: "enabled"
@@ -629,18 +621,14 @@ scripts:
       with:
         var-name: RUN.output.results.${{RUNTIMECMD.name}}.rss.avFirstRequestRss
         array: RUN.output.results.${{RUNTIMECMD.name}}.rss.firstRequest
-    - read-state: ${{config.energy.idrac}}
+    - read-state: ${{RUN.IDRAC_AVAILABLE}}
       then:
-        - regex: "enabled"
+        - regex: "true"
           then:
-            - sh: "command -v racadm > /dev/null 2>&1 && echo IDRAC_READY"
-              then:
-                - regex: IDRAC_READY
-                  then:
-                    - script: state-array-calc-avg
-                      with:
-                        var-name: RUN.output.results.${{RUNTIMECMD.name}}.energy.avIdrac
-                        array: RUN.output.results.${{RUNTIMECMD.name}}.energy.idrac
+            - script: state-array-calc-avg
+              with:
+                var-name: RUN.output.results.${{RUNTIMECMD.name}}.energy.avIdrac
+                array: RUN.output.results.${{RUNTIMECMD.name}}.energy.idrac
     - read-state: ${{config.energy.rapl}}
       then:
         - regex: "enabled"
@@ -908,6 +896,7 @@ roles:
       - capture-repo-info
       - stop-test-services
       - install-rapl-plot
+      - validate-idrac
       - start-timestamp
     run-scripts:
       - run-tests

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -547,6 +547,8 @@ scripts:
                           with:
                             command: ${{RUN.RAPL_BIN}} -p > ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.rapl &
                         - sh: echo $!
+                          then:
+                            - set-state: RUN.RAPL_PID
         - read-state: ${{config.energy.idrac}}
           then:
             - regex: "enabled"
@@ -600,6 +602,10 @@ scripts:
                   then:
                     - regex: RAPL_READY
                       then:
+                        - script: sudo
+                          with:
+                            command: kill ${{RUN.RAPL_PID}}
+                        - sh: sleep 1
                         - sh: awk -F', ' '/^[^#]/{s+=$2; d+=$4; n++} END{if(n>0) printf "%.2f %.2f", s/n, d/n; else print "0 0"}' ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.rapl
                           then:
                             - regex: (?<pkg>\S+) (?<dram>\S+)

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -14,6 +14,9 @@ states:
   config.units.load.throughputDensity: tps per MiB
   config.units.load.errors.connectionErrors: absolute number
   config.units.load.errors.requestTimeouts: absolute number
+  config.units.energy.idrac: W
+  config.units.energy.raplPkg: W
+  config.units.energy.raplDram: W
 
   config.jvm.home: #/path/to/java
   config.jvm.version: 25.0.2-tem
@@ -42,6 +45,8 @@ states:
   config.resources.cpu.monitor: 11
   config.resources.cpu.otel: 12-14
 
+  config.energy.rapl: enabled #disabled
+  config.energy.idrac: enabled #disabled
   config.profiler.name: none #jfr syncjfr flamegraph
   config.profiler.events: cpu
 
@@ -517,15 +522,43 @@ scripts:
         var-name: RUN.output.results.${{RUNTIMECMD.name}}.startup.avStartTime
         array: RUN.output.results.${{RUNTIMECMD.name}}.startup.timings
 
-  measure-rss:
+  measure-rss: # also measures energy
     - log: Measuring RSS
     - sh: java -version
     - sh: cd ${{RUNTIMECMD.dir}}
     - for-each: ITERATION ${{=[...Array(${{config.num_iterations}}).keys()]}}
       then:
+        - set-state: RUN.OUTPUT_DIR ${{REPO_DIR}}/logs
+        - set-state: RUN.COMPLETE_SIGNAL measure-rss-${{RUNTIMECMD.name}}-${{ITERATION}}
         - queue-download: ${{REPO_DIR}}/logs/measure-rss-${{RUNTIMECMD.name}}-${{ITERATION}}.log
+        - queue-download: ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.rapl
+        - queue-download: ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.svrPwr
         - script: start-test-services
         - script: sync-drop-fs-cache
+        - read-state: ${{config.energy.rapl}}
+          then:
+            - regex: "enabled"
+              then:
+                - sh: "[[ -x ${{RUN.RAPL_BIN:__NORAPL__}} ]] && echo RAPL_READY"
+                  then:
+                    - regex: RAPL_READY
+                      then:
+                        - script: sudo
+                          with:
+                            command: ${{RUN.RAPL_BIN}} -p > ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.rapl &
+                        - sh: echo $!
+        - read-state: ${{config.energy.idrac}}
+          then:
+            - regex: "enabled"
+              then:
+                - sh: "command -v racadm > /dev/null 2>&1 && echo IDRAC_READY"
+                  then:
+                    - regex: IDRAC_READY
+                      then:
+                        - set-signal: ${{COMPLETE_SIGNAL}} 1
+                        - script:
+                            name: capture-system-power
+                            async: true
         - sh: ${{RUNTIMECMD.runCmd}} &>${{REPO_DIR}}/logs/measure-rss-${{RUNTIMECMD.name}}-${{ITERATION}}.log &
         - sh: APP_PID=$!
         - sh: sleep ${{PAUSE_TIME}}
@@ -544,6 +577,41 @@ scripts:
           with:
             array: RUN.output.results.${{RUNTIMECMD.name}}.rss.firstRequest
             value: ${{= ${{FIRST_REQUEST}}/1024 }}
+        - read-state: ${{config.energy.idrac}}
+          then:
+            - regex: "enabled"
+              then:
+                - sh: "command -v racadm > /dev/null 2>&1 && echo IDRAC_READY"
+                  then:
+                    - regex: IDRAC_READY
+                      then:
+                        - signal: ${{COMPLETE_SIGNAL}}
+                        - sh: echo "${{RUN.svrPwr}}" > ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.svrPwr
+                        - set-state: IDRAC_AVG_WATTS ${{= (${{RUN.svrPwr}}.reduce((a, b) => a + b, 0) / ${{RUN.svrPwr}}.length) || 0 }}
+                        - script: state-array-push
+                          with:
+                            array: RUN.output.results.${{RUNTIMECMD.name}}.energy.idrac
+                            value: ${{IDRAC_AVG_WATTS}}
+        - read-state: ${{config.energy.rapl}}
+          then:
+            - regex: "enabled"
+              then:
+                - sh: "[[ -x ${{RUN.RAPL_BIN:__NORAPL__}} ]] && echo RAPL_READY"
+                  then:
+                    - regex: RAPL_READY
+                      then:
+                        - sh: awk -F', ' '/^[^#]/{s+=$2; d+=$4; n++} END{if(n>0) printf "%.2f %.2f", s/n, d/n; else print "0 0"}' ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.rapl
+                          then:
+                            - regex: (?<pkg>\S+) (?<dram>\S+)
+                              then:
+                                - script: state-array-push
+                                  with:
+                                    array: RUN.output.results.${{RUNTIMECMD.name}}.energy.raplPkg
+                                    value: ${{pkg}}
+                                - script: state-array-push
+                                  with:
+                                    array: RUN.output.results.${{RUNTIMECMD.name}}.energy.raplDram
+                                    value: ${{dram}}
         - sh: kill -15 $APP_PID
         - sh: sleep ${{PAUSE_TIME}}
         - script: stop-test-services
@@ -555,6 +623,34 @@ scripts:
       with:
         var-name: RUN.output.results.${{RUNTIMECMD.name}}.rss.avFirstRequestRss
         array: RUN.output.results.${{RUNTIMECMD.name}}.rss.firstRequest
+    - read-state: ${{config.energy.idrac}}
+      then:
+        - regex: "enabled"
+          then:
+            - sh: "command -v racadm > /dev/null 2>&1 && echo IDRAC_READY"
+              then:
+                - regex: IDRAC_READY
+                  then:
+                    - script: state-array-calc-avg
+                      with:
+                        var-name: RUN.output.results.${{RUNTIMECMD.name}}.energy.avIdrac
+                        array: RUN.output.results.${{RUNTIMECMD.name}}.energy.idrac
+    - read-state: ${{config.energy.rapl}}
+      then:
+        - regex: "enabled"
+          then:
+            - sh: "[[ -x ${{RUN.RAPL_BIN:__NORAPL__}} ]] && echo RAPL_READY"
+              then:
+                - regex: RAPL_READY
+                  then:
+                    - script: state-array-calc-avg
+                      with:
+                        var-name: RUN.output.results.${{RUNTIMECMD.name}}.energy.avRaplPkg
+                        array: RUN.output.results.${{RUNTIMECMD.name}}.energy.raplPkg
+                    - script: state-array-calc-avg
+                      with:
+                        var-name: RUN.output.results.${{RUNTIMECMD.name}}.energy.avRaplDram
+                        array: RUN.output.results.${{RUNTIMECMD.name}}.energy.raplDram
 
   run-load-test:
     - log: Running workload
@@ -805,6 +901,7 @@ roles:
       - ensure-container-runtime
       - capture-repo-info
       - stop-test-services
+      - install-rapl-plot
       - start-timestamp
     run-scripts:
       - run-tests

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -17,6 +17,7 @@ states:
   config.units.energy.idrac: J
   config.units.energy.raplPkg: J
   config.units.energy.raplDram: J
+  config.units.energy.throughput: tps
 
   config.jvm.home: #/path/to/java
   config.jvm.version: 25.0.2-tem
@@ -47,7 +48,8 @@ states:
 
   config.energy.rapl: enabled #disabled
   config.energy.idrac: enabled #disabled
-  config.energy.rss.duration: 150
+  config.energy.fixed.rate: 5000
+  config.energy.fixed.duration: 150
   config.profiler.name: none #jfr syncjfr flamegraph
   config.profiler.events: cpu
 
@@ -536,28 +538,7 @@ scripts:
         - queue-download: ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.svrPwr
         - script: start-test-services
         - script: sync-drop-fs-cache
-        - read-state: ${{config.energy.rapl}}
-          then:
-            - regex: "enabled"
-              then:
-                - sh: "[[ -x ${{RUN.RAPL_BIN:__NORAPL__}} ]] && echo RAPL_READY"
-                  then:
-                    - regex: RAPL_READY
-                      then:
-                        - script: sudo
-                          with:
-                            command: ${{RUN.RAPL_BIN}} -p > ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.rapl &
-                        - sh: echo $!
-                          then:
-                            - set-state: RUN.RAPL_PID
-        - read-state: ${{RUN.IDRAC_AVAILABLE}}
-          then:
-            - regex: "true"
-              then:
-                - set-signal: ${{COMPLETE_SIGNAL}} 1
-                - script:
-                    name: capture-system-power
-                    async: true
+        - script: start-energy-capture
         - sh: ${{RUNTIMECMD.runCmd}} &>${{REPO_DIR}}/logs/measure-rss-${{RUNTIMECMD.name}}-${{ITERATION}}.log &
         - sh: APP_PID=$!
         - sh: sleep ${{PAUSE_TIME}}
@@ -576,42 +557,9 @@ scripts:
           with:
             array: RUN.output.results.${{RUNTIMECMD.name}}.rss.firstRequest
             value: ${{= ${{FIRST_REQUEST}}/1024 }}
-        - sh: sleep ${{config.energy.rss.duration}}
-        - read-state: ${{RUN.IDRAC_AVAILABLE}}
-          then:
-            - regex: "true"
-              then:
-                - signal: ${{COMPLETE_SIGNAL}}
-                - sh: echo "${{RUN.svrPwr}}" > ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.svrPwr
-                - set-state: IDRAC_ENERGY ${{= ${{RUN.svrPwr}}.reduce((a, b) => a + b, 0) || 0 }}
-                - script: state-array-push
-                  with:
-                    array: RUN.output.results.${{RUNTIMECMD.name}}.energy.idrac
-                    value: ${{IDRAC_ENERGY}}
-        - read-state: ${{config.energy.rapl}}
-          then:
-            - regex: "enabled"
-              then:
-                - sh: "[[ -x ${{RUN.RAPL_BIN:__NORAPL__}} ]] && echo RAPL_READY"
-                  then:
-                    - regex: RAPL_READY
-                      then:
-                        - script: sudo
-                          with:
-                            command: kill ${{RUN.RAPL_PID}}
-                        - sh: sleep 1
-                        - sh: awk -F', ' '/^[^#]/{s+=$2; d+=$4} END{printf "%.2f %.2f", s, d}' ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.rapl
-                          then:
-                            - regex: (?<pkg>\S+) (?<dram>\S+)
-                              then:
-                                - script: state-array-push
-                                  with:
-                                    array: RUN.output.results.${{RUNTIMECMD.name}}.energy.raplPkg
-                                    value: ${{pkg}}
-                                - script: state-array-push
-                                  with:
-                                    array: RUN.output.results.${{RUNTIMECMD.name}}.energy.raplDram
-                                    value: ${{dram}}
+        - script: stop-energy-capture
+          with:
+            result_prefix: RUN.output.results.${{RUNTIMECMD.name}}.energy
         - sh: kill -15 $APP_PID
         - sh: sleep ${{PAUSE_TIME}}
         - script: stop-test-services
@@ -623,30 +571,9 @@ scripts:
       with:
         var-name: RUN.output.results.${{RUNTIMECMD.name}}.rss.avFirstRequestRss
         array: RUN.output.results.${{RUNTIMECMD.name}}.rss.firstRequest
-    - read-state: ${{RUN.IDRAC_AVAILABLE}}
-      then:
-        - regex: "true"
-          then:
-            - script: state-array-calc-avg
-              with:
-                var-name: RUN.output.results.${{RUNTIMECMD.name}}.energy.avIdrac
-                array: RUN.output.results.${{RUNTIMECMD.name}}.energy.idrac
-    - read-state: ${{config.energy.rapl}}
-      then:
-        - regex: "enabled"
-          then:
-            - sh: "[[ -x ${{RUN.RAPL_BIN:__NORAPL__}} ]] && echo RAPL_READY"
-              then:
-                - regex: RAPL_READY
-                  then:
-                    - script: state-array-calc-avg
-                      with:
-                        var-name: RUN.output.results.${{RUNTIMECMD.name}}.energy.avRaplPkg
-                        array: RUN.output.results.${{RUNTIMECMD.name}}.energy.raplPkg
-                    - script: state-array-calc-avg
-                      with:
-                        var-name: RUN.output.results.${{RUNTIMECMD.name}}.energy.avRaplDram
-                        array: RUN.output.results.${{RUNTIMECMD.name}}.energy.raplDram
+    - script: calc-energy-totals
+      with:
+        result_prefix: RUN.output.results.${{RUNTIMECMD.name}}.energy
 
   run-load-test:
     - log: Running workload
@@ -799,6 +726,128 @@ scripts:
       with:
         var-name: RUN.output.results.${{RUNTIMECMD.name}}.load.avRequestTimeouts
         array: RUN.output.results.${{RUNTIMECMD.name}}.load.requestTimeouts
+
+  measure-energy-max-throughput:
+    - log: Measuring energy at max throughput
+    - sh: cd ${{RUNTIMECMD.dir}}
+    - set-state:
+        key: APP_LOG_REGEX
+        value: ${{RUNTIMECMD.logFileStartedRegex}}
+    - for-each: ITERATION ${{=[...Array(${{config.num_iterations}}).keys()]}}
+      then:
+        - set-state: RUN.OUTPUT_DIR ${{REPO_DIR}}/logs
+        - set-state: RUN.COMPLETE_SIGNAL energy-max-${{RUNTIMECMD.name}}-${{ITERATION}}
+        - set-state:
+            key: LOG_FILE
+            value: ${{REPO_DIR}}/logs/energy-max-${{RUNTIMECMD.name}}-${{ITERATION}}.log
+        - sh: touch ${{LOG_FILE}}
+        - queue-download: ${{LOG_FILE}}
+        - queue-download: ${{REPO_DIR}}/logs/wrk-energy-max-warmup-${{RUNTIMECMD.name}}-${{ITERATION}}.log
+        - queue-download: ${{REPO_DIR}}/logs/wrk-energy-max-${{RUNTIMECMD.name}}-${{ITERATION}}.log
+        - queue-download: ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.rapl
+        - queue-download: ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.svrPwr
+        - script: start-test-services
+        - script: sync-drop-fs-cache
+        - set-signal: LOG_REGEX_REACHED 1
+        - sh: ${{RUNTIMECMD.runCmd}} &>${{LOG_FILE}} &
+        - sh: PID=$!
+        - sh: echo $PID
+        - set-state: JVM_PID
+        - script:
+            name: watch-log
+            async: true
+          with:
+            log_file: ${{LOG_FILE}}
+            log_regex: ${{APP_LOG_REGEX}}
+        - wait-for: LOG_REGEX_REACHED
+        - sh: ${{RUN.WRK_BIN}} -t 2 -c 100 -d 2m --timeout 2m ${{TARGET_URL}} 2>&1 >${{REPO_DIR}}/logs/wrk-energy-max-warmup-${{RUNTIMECMD.name}}-${{ITERATION}}.log
+        - sleep: 30s
+        - script: start-energy-capture
+        - sh: ${{RUN.WRK_BIN}} -t 2 -c 100 -d 30s --timeout 30s ${{TARGET_URL}} > ${{REPO_DIR}}/logs/wrk-energy-max-${{RUNTIMECMD.name}}-${{ITERATION}}.log 2>&1 &
+        - sh: WRK_PID=$! && echo $WRK_PID
+        - set-state: WRK_PID
+        - sh: wait ${{WRK_PID}}
+        - sh: cat ${{REPO_DIR}}/logs/wrk-energy-max-${{RUNTIMECMD.name}}-${{ITERATION}}.log | grep "Requests/sec" | awk '{print $2}'
+          then:
+            - set-state: THROUGHPUT
+        - script: state-array-push
+          with:
+            array: RUN.output.results.${{RUNTIMECMD.name}}.energyMaxLoad.throughput
+            value: ${{THROUGHPUT}}
+        - script: stop-energy-capture
+          with:
+            result_prefix: RUN.output.results.${{RUNTIMECMD.name}}.energyMaxLoad
+        - sh: kill -15 $PID
+        - sh: sleep ${{PAUSE_TIME}}
+        - script: stop-test-services
+    - script: state-array-calc-avg
+      with:
+        var-name: RUN.output.results.${{RUNTIMECMD.name}}.energyMaxLoad.avThroughput
+        array: RUN.output.results.${{RUNTIMECMD.name}}.energyMaxLoad.throughput
+    - script: calc-energy-totals
+      with:
+        result_prefix: RUN.output.results.${{RUNTIMECMD.name}}.energyMaxLoad
+
+  measure-energy-fixed-throughput:
+    - log: Measuring energy at fixed throughput (${{config.energy.fixed.rate}} tps)
+    - sh: cd ${{RUNTIMECMD.dir}}
+    - set-state:
+        key: APP_LOG_REGEX
+        value: ${{RUNTIMECMD.logFileStartedRegex}}
+    - for-each: ITERATION ${{=[...Array(${{config.num_iterations}}).keys()]}}
+      then:
+        - set-state: RUN.OUTPUT_DIR ${{REPO_DIR}}/logs
+        - set-state: RUN.COMPLETE_SIGNAL energy-fixed-${{RUNTIMECMD.name}}-${{ITERATION}}
+        - set-state:
+            key: LOG_FILE
+            value: ${{REPO_DIR}}/logs/energy-fixed-${{RUNTIMECMD.name}}-${{ITERATION}}.log
+        - sh: touch ${{LOG_FILE}}
+        - queue-download: ${{LOG_FILE}}
+        - queue-download: ${{REPO_DIR}}/logs/wrk-energy-fixed-warmup-${{RUNTIMECMD.name}}-${{ITERATION}}.log
+        - queue-download: ${{REPO_DIR}}/logs/wrk-energy-fixed-${{RUNTIMECMD.name}}-${{ITERATION}}.log
+        - queue-download: ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.rapl
+        - queue-download: ${{OUTPUT_DIR}}/${{COMPLETE_SIGNAL}}.svrPwr
+        - script: start-test-services
+        - script: sync-drop-fs-cache
+        - set-signal: LOG_REGEX_REACHED 1
+        - sh: ${{RUNTIMECMD.runCmd}} &>${{LOG_FILE}} &
+        - sh: PID=$!
+        - sh: echo $PID
+        - set-state: JVM_PID
+        - script:
+            name: watch-log
+            async: true
+          with:
+            log_file: ${{LOG_FILE}}
+            log_regex: ${{APP_LOG_REGEX}}
+        - wait-for: LOG_REGEX_REACHED
+        - sh: ${{RUN.WRK_BIN}} -t 2 -c 100 -d 30s -R ${{config.energy.fixed.rate}} --timeout 30s ${{TARGET_URL}} 2>&1 >${{REPO_DIR}}/logs/wrk-energy-fixed-warmup-${{RUNTIMECMD.name}}-${{ITERATION}}.log
+        - sleep: 10s
+        - script: start-energy-capture
+        - sh: ${{RUN.WRK_BIN}} -t 2 -c 100 -d ${{config.energy.fixed.duration}}s -R ${{config.energy.fixed.rate}} --timeout ${{config.energy.fixed.duration}}s ${{TARGET_URL}} > ${{REPO_DIR}}/logs/wrk-energy-fixed-${{RUNTIMECMD.name}}-${{ITERATION}}.log 2>&1 &
+        - sh: WRK_PID=$! && echo $WRK_PID
+        - set-state: WRK_PID
+        - sh: wait ${{WRK_PID}}
+        - sh: cat ${{REPO_DIR}}/logs/wrk-energy-fixed-${{RUNTIMECMD.name}}-${{ITERATION}}.log | grep "Requests/sec" | awk '{print $2}'
+          then:
+            - set-state: THROUGHPUT
+        - script: state-array-push
+          with:
+            array: RUN.output.results.${{RUNTIMECMD.name}}.energyFixedLoad.throughput
+            value: ${{THROUGHPUT}}
+        - script: stop-energy-capture
+          with:
+            result_prefix: RUN.output.results.${{RUNTIMECMD.name}}.energyFixedLoad
+        - sh: kill -15 $PID
+        - sh: sleep ${{PAUSE_TIME}}
+        - script: stop-test-services
+    - script: state-array-calc-avg
+      with:
+        var-name: RUN.output.results.${{RUNTIMECMD.name}}.energyFixedLoad.avThroughput
+        array: RUN.output.results.${{RUNTIMECMD.name}}.energyFixedLoad.throughput
+    - script: calc-energy-totals
+      with:
+        result_prefix: RUN.output.results.${{RUNTIMECMD.name}}.energyFixedLoad
 
   watch-log:
     - sh: tail -f ${{log_file}}

--- a/scripts/perf-lab/run-benchmarks.sh
+++ b/scripts/perf-lab/run-benchmarks.sh
@@ -103,7 +103,7 @@ help() {
   echo "                                                              NOTE: Its a good practice to set this manually to ensure proper version"
   echo "  --tests <TESTS_TO_RUN>                                  The tests to run, separated by commas"
   echo "                                                              Accepted values (1 or more of): measure-build-times, measure-time-to-first-request, measure-rss, run-load-test, measure-energy-fixed-throughput"
-  echo "                                                              Default: 'measure-time-to-first-request,measure-rss,run-load-test'"
+  echo "                                                              Default: 'measure-time-to-first-request,measure-rss,run-load-test,measure-energy-fixed-throughput'"
   echo "                                                              NOTE: Build times (measure-build-times) are always measured during the build phase"
   echo "  --user <USER>                                           The user on <HOST> to run the benchmark"
   echo "  --use-container-host-network                            Use host networking instead of port mapping on infra containers"
@@ -364,7 +364,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   SPRING_BOOT3_VERSION=""
   SPRING_BOOT4_VERSION=""
   ALLOWED_TESTS_TO_RUN=("measure-build-times" "measure-time-to-first-request" "measure-rss" "run-load-test" "measure-energy-fixed-throughput")
-  DEFAULT_TESTS_TO_RUN=("measure-time-to-first-request" "measure-rss" "run-load-test")
+  DEFAULT_TESTS_TO_RUN=("measure-time-to-first-request" "measure-rss" "run-load-test" "measure-energy-fixed-throughput")
   TESTS_TO_RUN=${DEFAULT_TESTS_TO_RUN[@]}
   USER=""
   JVM_MEMORY="-Xms512m -Xmx512m"

--- a/scripts/perf-lab/run-benchmarks.sh
+++ b/scripts/perf-lab/run-benchmarks.sh
@@ -102,7 +102,7 @@ help() {
   echo "                                                              Default: Whatever version is set in pom.xml of the Spring Boot 4 app"
   echo "                                                              NOTE: Its a good practice to set this manually to ensure proper version"
   echo "  --tests <TESTS_TO_RUN>                                  The tests to run, separated by commas"
-  echo "                                                              Accepted values (1 or more of): measure-build-times, measure-time-to-first-request, measure-rss, run-load-test, measure-energy-max-throughput, measure-energy-fixed-throughput"
+  echo "                                                              Accepted values (1 or more of): measure-build-times, measure-time-to-first-request, measure-rss, run-load-test, measure-energy-fixed-throughput"
   echo "                                                              Default: 'measure-time-to-first-request,measure-rss,run-load-test'"
   echo "                                                              NOTE: Build times (measure-build-times) are always measured during the build phase"
   echo "  --user <USER>                                           The user on <HOST> to run the benchmark"
@@ -363,7 +363,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   RUNTIMES=${DEFAULT_RUNTIMES[@]}
   SPRING_BOOT3_VERSION=""
   SPRING_BOOT4_VERSION=""
-  ALLOWED_TESTS_TO_RUN=("measure-build-times" "measure-time-to-first-request" "measure-rss" "run-load-test" "measure-energy-max-throughput" "measure-energy-fixed-throughput")
+  ALLOWED_TESTS_TO_RUN=("measure-build-times" "measure-time-to-first-request" "measure-rss" "run-load-test" "measure-energy-fixed-throughput")
   DEFAULT_TESTS_TO_RUN=("measure-time-to-first-request" "measure-rss" "run-load-test")
   TESTS_TO_RUN=${DEFAULT_TESTS_TO_RUN[@]}
   USER=""

--- a/scripts/perf-lab/run-benchmarks.sh
+++ b/scripts/perf-lab/run-benchmarks.sh
@@ -415,13 +415,14 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         elif [[ "$2" == "none" ]]; then
           : # both already disabled
         else
-          en=($(IFS=','; echo $2))
+          IFS=',' read -ra en <<< "$2"
 
           for item in "${en[@]}"; do
-            if [[ ! "${ALLOWED_ENERGY[@]}" =~ "${item}" ]]; then
-              echo "!! [ERROR] --energy option must be 'all', 'none', or 1 or more of [${ALLOWED_ENERGY[@]}]!!"
-              exit_abnormal
-            fi
+            case "$item" in
+              rapl|idrac) ;;
+              *) echo "!! [ERROR] --energy option must be 'all', 'none', or 1 or more of [${ALLOWED_ENERGY[@]}]!!"
+                 exit_abnormal ;;
+            esac
           done
 
           for item in "${en[@]}"; do

--- a/scripts/perf-lab/run-benchmarks.sh
+++ b/scripts/perf-lab/run-benchmarks.sh
@@ -37,6 +37,10 @@ help() {
   echo "  --cpus-otel <CPUS_OTEL>                                 CPU list for the OpenTelemetry stack (e.g. 14,16,18)"
   echo "                                                              Default: ${CPUS_OTEL}"
   echo "  --description <DESCRIPTION>                             A human-readable description to be added to the run output"
+  echo "  --energy <ENERGY>                                       Energy measurement sources, separated by commas"
+  echo "                                                              Accepted values (1 or more of): rapl, idrac"
+  echo "                                                              Special values: all, none"
+  echo "                                                              Default: 'all'"
   echo "  --drop-fs-caches                                        Purge/drop OS filesystem caches between iterations"
   echo "  --extra-qdup-args <EXTRA_QDUP_ARGS>                     Any extra arguments that need to be passed to qDup ahead of the qDup scripts"
   echo "                                                              NOTE: This is an advanced option. Make sure you know what you are doing when using it."
@@ -149,6 +153,9 @@ print_values() {
   echo "  NATIVE_QUARKUS_BUILD_OPTIONS: $NATIVE_QUARKUS_BUILD_OPTIONS"
   echo "  NATIVE_SPRING3_BUILD_OPTIONS: $NATIVE_SPRING3_BUILD_OPTIONS"
   echo "  NATIVE_SPRING4_BUILD_OPTIONS: $NATIVE_SPRING4_BUILD_OPTIONS"
+  echo "  ENERGY: $ENERGY"
+  echo "  ENERGY_IDRAC: $ENERGY_IDRAC"
+  echo "  ENERGY_RAPL: $ENERGY_RAPL"
   echo "  PROFILER: $PROFILER"
   echo "  QUARKUS_BUILD_CONFIG_ARGS: $QUARKUS_BUILD_CONFIG_ARGS"
   echo "  QUARKUS_VERSION: $QUARKUS_VERSION"
@@ -274,6 +281,8 @@ ${JBANG_CMD} io.hyperfoil.tools:qDup:0.11.0 \
     -S config.jvm.version=${JAVA_VERSION} \
     -S config.quarkus.native_build_options="${NATIVE_QUARKUS_BUILD_OPTIONS}" \
     -S config.jvm.args="${JVM_ARGS}" \
+    -S config.energy.idrac=${ENERGY_IDRAC} \
+    -S config.energy.rapl=${ENERGY_RAPL} \
     -S config.profiler.name=${PROFILER} \
     -S config.resources.app_cpus="$(count_cpus "${CPUS_APP}")" \
     -S config.resources.cpu.app="${CPUS_APP}" \
@@ -332,6 +341,10 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   NATIVE_QUARKUS_BUILD_OPTIONS=""
   NATIVE_SPRING3_BUILD_OPTIONS=""
   NATIVE_SPRING4_BUILD_OPTIONS=""
+  ENERGY="all"
+  ALLOWED_ENERGY=("rapl" "idrac")
+  ENERGY_IDRAC="enabled"
+  ENERGY_RAPL="enabled"
   PROFILER="none"
   QUARKUS_BUILD_CONFIG_ARGS=""
   QUARKUS_VERSION=""
@@ -388,6 +401,37 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
       --use-container-host-network)
         USE_CONTAINER_HOST_NETWORK=true
         shift
+        ;;
+
+      --energy)
+        ENERGY_SET_BY_USER="true"
+        ENERGY="$2"
+        ENERGY_IDRAC="disabled"
+        ENERGY_RAPL="disabled"
+
+        if [[ "$2" == "all" ]]; then
+          ENERGY_IDRAC="enabled"
+          ENERGY_RAPL="enabled"
+        elif [[ "$2" == "none" ]]; then
+          : # both already disabled
+        else
+          en=($(IFS=','; echo $2))
+
+          for item in "${en[@]}"; do
+            if [[ ! "${ALLOWED_ENERGY[@]}" =~ "${item}" ]]; then
+              echo "!! [ERROR] --energy option must be 'all', 'none', or 1 or more of [${ALLOWED_ENERGY[@]}]!!"
+              exit_abnormal
+            fi
+          done
+
+          for item in "${en[@]}"; do
+            case "$item" in
+              rapl) ENERGY_RAPL="enabled" ;;
+              idrac) ENERGY_IDRAC="enabled" ;;
+            esac
+          done
+        fi
+        shift 2
         ;;
 
       --extra-qdup-args)
@@ -584,6 +628,11 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     fi
   done
   TESTS_TO_RUN=${filtered_tests[@]}
+
+  # If user explicitly set --energy, ensure measure-rss is in the test list
+  if [[ -n "${ENERGY_SET_BY_USER:-}" && "$ENERGY" != "none" && ! "${TESTS_TO_RUN[@]}" =~ "measure-rss" ]]; then
+    TESTS_TO_RUN="$TESTS_TO_RUN measure-rss"
+  fi
 
   validate_values
   calculate_scenario

--- a/scripts/perf-lab/run-benchmarks.sh
+++ b/scripts/perf-lab/run-benchmarks.sh
@@ -41,6 +41,8 @@ help() {
   echo "                                                              Accepted values (1 or more of): rapl, idrac"
   echo "                                                              Special values: all, none"
   echo "                                                              Default: 'all'"
+  echo "  --energy-duration <SECONDS>                             Duration (seconds) to sustain energy measurement after RSS is captured"
+  echo "                                                              Default: 150 (matches load test duration)"
   echo "  --drop-fs-caches                                        Purge/drop OS filesystem caches between iterations"
   echo "  --extra-qdup-args <EXTRA_QDUP_ARGS>                     Any extra arguments that need to be passed to qDup ahead of the qDup scripts"
   echo "                                                              NOTE: This is an advanced option. Make sure you know what you are doing when using it."
@@ -154,6 +156,7 @@ print_values() {
   echo "  NATIVE_SPRING3_BUILD_OPTIONS: $NATIVE_SPRING3_BUILD_OPTIONS"
   echo "  NATIVE_SPRING4_BUILD_OPTIONS: $NATIVE_SPRING4_BUILD_OPTIONS"
   echo "  ENERGY: $ENERGY"
+  echo "  ENERGY_DURATION: $ENERGY_DURATION"
   echo "  ENERGY_IDRAC: $ENERGY_IDRAC"
   echo "  ENERGY_RAPL: $ENERGY_RAPL"
   echo "  PROFILER: $PROFILER"
@@ -283,6 +286,7 @@ ${JBANG_CMD} io.hyperfoil.tools:qDup:0.11.0 \
     -S config.jvm.args="${JVM_ARGS}" \
     -S config.energy.idrac=${ENERGY_IDRAC} \
     -S config.energy.rapl=${ENERGY_RAPL} \
+    -S config.energy.rss.duration=${ENERGY_DURATION} \
     -S config.profiler.name=${PROFILER} \
     -S config.resources.app_cpus="$(count_cpus "${CPUS_APP}")" \
     -S config.resources.cpu.app="${CPUS_APP}" \
@@ -343,6 +347,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   NATIVE_SPRING4_BUILD_OPTIONS=""
   ENERGY="all"
   ALLOWED_ENERGY=("rapl" "idrac")
+  ENERGY_DURATION=150
   ENERGY_IDRAC="enabled"
   ENERGY_RAPL="enabled"
   PROFILER="none"
@@ -413,7 +418,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
           ENERGY_IDRAC="enabled"
           ENERGY_RAPL="enabled"
         elif [[ "$2" == "none" ]]; then
-          : # both already disabled
+          ENERGY_DURATION=0
         else
           IFS=',' read -ra en <<< "$2"
 
@@ -432,6 +437,11 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
             esac
           done
         fi
+        shift 2
+        ;;
+
+      --energy-duration)
+        ENERGY_DURATION="$2"
         shift 2
         ;;
 

--- a/scripts/perf-lab/run-benchmarks.sh
+++ b/scripts/perf-lab/run-benchmarks.sh
@@ -41,8 +41,10 @@ help() {
   echo "                                                              Accepted values (1 or more of): rapl, idrac"
   echo "                                                              Special values: all, none"
   echo "                                                              Default: 'all'"
-  echo "  --energy-duration <SECONDS>                             Duration (seconds) to sustain energy measurement after RSS is captured"
-  echo "                                                              Default: 150 (matches load test duration)"
+  echo "  --fixed-throughput-duration <SECONDS>                    Duration (seconds) for fixed throughput energy measurement"
+  echo "                                                              Default: 150"
+  echo "  --fixed-throughput-rate <RATE>                           Request rate (tps) for fixed throughput energy measurement"
+  echo "                                                              Default: 5000"
   echo "  --drop-fs-caches                                        Purge/drop OS filesystem caches between iterations"
   echo "  --extra-qdup-args <EXTRA_QDUP_ARGS>                     Any extra arguments that need to be passed to qDup ahead of the qDup scripts"
   echo "                                                              NOTE: This is an advanced option. Make sure you know what you are doing when using it."
@@ -100,7 +102,7 @@ help() {
   echo "                                                              Default: Whatever version is set in pom.xml of the Spring Boot 4 app"
   echo "                                                              NOTE: Its a good practice to set this manually to ensure proper version"
   echo "  --tests <TESTS_TO_RUN>                                  The tests to run, separated by commas"
-  echo "                                                              Accepted values (1 or more of): measure-build-times, measure-time-to-first-request, measure-rss, run-load-test"
+  echo "                                                              Accepted values (1 or more of): measure-build-times, measure-time-to-first-request, measure-rss, run-load-test, measure-energy-max-throughput, measure-energy-fixed-throughput"
   echo "                                                              Default: 'measure-time-to-first-request,measure-rss,run-load-test'"
   echo "                                                              NOTE: Build times (measure-build-times) are always measured during the build phase"
   echo "  --user <USER>                                           The user on <HOST> to run the benchmark"
@@ -156,7 +158,8 @@ print_values() {
   echo "  NATIVE_SPRING3_BUILD_OPTIONS: $NATIVE_SPRING3_BUILD_OPTIONS"
   echo "  NATIVE_SPRING4_BUILD_OPTIONS: $NATIVE_SPRING4_BUILD_OPTIONS"
   echo "  ENERGY: $ENERGY"
-  echo "  ENERGY_DURATION: $ENERGY_DURATION"
+  echo "  FIXED_THROUGHPUT_DURATION: $FIXED_THROUGHPUT_DURATION"
+  echo "  FIXED_THROUGHPUT_RATE: $FIXED_THROUGHPUT_RATE"
   echo "  ENERGY_IDRAC: $ENERGY_IDRAC"
   echo "  ENERGY_RAPL: $ENERGY_RAPL"
   echo "  PROFILER: $PROFILER"
@@ -286,7 +289,8 @@ ${JBANG_CMD} io.hyperfoil.tools:qDup:0.11.0 \
     -S config.jvm.args="${JVM_ARGS}" \
     -S config.energy.idrac=${ENERGY_IDRAC} \
     -S config.energy.rapl=${ENERGY_RAPL} \
-    -S config.energy.rss.duration=${ENERGY_DURATION} \
+    -S config.energy.fixed.rate=${FIXED_THROUGHPUT_RATE} \
+    -S config.energy.fixed.duration=${FIXED_THROUGHPUT_DURATION} \
     -S config.profiler.name=${PROFILER} \
     -S config.resources.app_cpus="$(count_cpus "${CPUS_APP}")" \
     -S config.resources.cpu.app="${CPUS_APP}" \
@@ -347,7 +351,8 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   NATIVE_SPRING4_BUILD_OPTIONS=""
   ENERGY="all"
   ALLOWED_ENERGY=("rapl" "idrac")
-  ENERGY_DURATION=150
+  FIXED_THROUGHPUT_DURATION=150
+  FIXED_THROUGHPUT_RATE=5000
   ENERGY_IDRAC="enabled"
   ENERGY_RAPL="enabled"
   PROFILER="none"
@@ -358,7 +363,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   RUNTIMES=${DEFAULT_RUNTIMES[@]}
   SPRING_BOOT3_VERSION=""
   SPRING_BOOT4_VERSION=""
-  ALLOWED_TESTS_TO_RUN=("measure-build-times" "measure-time-to-first-request" "measure-rss" "run-load-test")
+  ALLOWED_TESTS_TO_RUN=("measure-build-times" "measure-time-to-first-request" "measure-rss" "run-load-test" "measure-energy-max-throughput" "measure-energy-fixed-throughput")
   DEFAULT_TESTS_TO_RUN=("measure-time-to-first-request" "measure-rss" "run-load-test")
   TESTS_TO_RUN=${DEFAULT_TESTS_TO_RUN[@]}
   USER=""
@@ -418,7 +423,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
           ENERGY_IDRAC="enabled"
           ENERGY_RAPL="enabled"
         elif [[ "$2" == "none" ]]; then
-          ENERGY_DURATION=0
+          FIXED_THROUGHPUT_DURATION=0
         else
           IFS=',' read -ra en <<< "$2"
 
@@ -440,8 +445,13 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         shift 2
         ;;
 
-      --energy-duration)
-        ENERGY_DURATION="$2"
+      --fixed-throughput-duration)
+        FIXED_THROUGHPUT_DURATION="$2"
+        shift 2
+        ;;
+
+      --fixed-throughput-rate)
+        FIXED_THROUGHPUT_RATE="$2"
         shift 2
         ;;
 

--- a/scripts/perf-lab/run-benchmarks.sh
+++ b/scripts/perf-lab/run-benchmarks.sh
@@ -429,16 +429,10 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 
           for item in "${en[@]}"; do
             case "$item" in
-              rapl|idrac) ;;
-              *) echo "!! [ERROR] --energy option must be 'all', 'none', or 1 or more of [${ALLOWED_ENERGY[@]}]!!"
-                 exit_abnormal ;;
-            esac
-          done
-
-          for item in "${en[@]}"; do
-            case "$item" in
               rapl) ENERGY_RAPL="enabled" ;;
               idrac) ENERGY_IDRAC="enabled" ;;
+              *) echo "!! [ERROR] --energy option must be 'all', 'none', or 1 or more of [${ALLOWED_ENERGY[@]}]!!"
+                 exit_abnormal ;;
             esac
           done
         fi
@@ -446,11 +440,19 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         ;;
 
       --fixed-throughput-duration)
+        if ! [[ "$2" =~ ^[0-9]+$ ]]; then
+          echo "!! [ERROR] --fixed-throughput-duration must be a positive integer!!"
+          exit_abnormal
+        fi
         FIXED_THROUGHPUT_DURATION="$2"
         shift 2
         ;;
 
       --fixed-throughput-rate)
+        if ! [[ "$2" =~ ^[0-9]+$ ]]; then
+          echo "!! [ERROR] --fixed-throughput-rate must be a positive integer!!"
+          exit_abnormal
+        fi
         FIXED_THROUGHPUT_RATE="$2"
         shift 2
         ;;
@@ -649,11 +651,6 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     fi
   done
   TESTS_TO_RUN=${filtered_tests[@]}
-
-  # If user explicitly set --energy, ensure measure-rss is in the test list
-  if [[ -n "${ENERGY_SET_BY_USER:-}" && "$ENERGY" != "none" && ! "${TESTS_TO_RUN[@]}" =~ "measure-rss" ]]; then
-    TESTS_TO_RUN="$TESTS_TO_RUN measure-rss"
-  fi
 
   validate_values
   calculate_scenario


### PR DESCRIPTION
Resolves #99.

This is based on John O'Hara's work in the `quarkus-qe-spring-boot-comparison` branch of his old repo. I've copied the relevant qDup scripts from his yaml, and then added some extra logic to allow it to be turned on and off, guard execution on non-Intel hardware and non-Dell hardware, and report an average energy consumption into the json. 

The energy measurements will run as part of the same job that gathers rss information. That seems suitable, since it's fixed throughput, and we're running it already. (@franz1981 and @edeandrea, should that job be made longer, to get higher quality results?)

I'm stumbling in the dark a bit with the qDup, since this is my first time touching the scripts. I've tested as well as I can, but I don't have access to any Intel hardware, so I had to test by getting claude to stub out the rapl and idrac endpoints. That's not brilliant, so I'd be ever so grateful if @edeandrea or @franz1981 could test for me. :) 

These are the changes:

- Add RAPL (CPU-level) and iDRAC (system-level) power measurement to the `measure-rss` benchmark phase
 - New --energy-rapl and --energy-idrac CLI flags (enabled|disabled, default: enabled) to control which measurements run                           
  - Hardware guards silently skip unsupported measurements (e.g. no RAPL on ARM, no racadm on non-Dell), so both can safely be left enabled on any  platform  
- New `scripts/perf-lab/helpers/energy.yml` with `install-rapl-plot` and `capture-system-power` scripts

### Energy measurement outputs
- `.rapl` files — per-second CPU package and DRAM power readings from Intel RAPL
- `.svrPwr` files — per-second system-level wattage readings from Dell iDRAC/racadm
- new stanzas in the json. Claude claims they will look like this, with per-iteration average watts for each source, plus cross-iteration averages.                                    

```                                                                                                                                                    
  "energy": {                                                                                                                                       
    "idrac": [157, 155],                                                                                                                            
    "avIdrac": 156,                                                                                                                                 
    "raplPkg": [25.85, 26.10],                                                                                                                      
    "avRaplPkg": 25.975,                                                                                                                            
    "raplDram": [5.42, 5.38],                                                                                                                     
    "avRaplDram": 5.40                                                                                                                              
  }                                                                                                                                               
                                                                                                                                                   
```

