### PR TITLE
Configure Vert.x to use a single event loop for Loom integration with Quarkus

### DIFF
--- a/quarkus3-virtual/src/main/resources/application.yml
+++ b/quarkus3-virtual/src/main/resources/application.yml
@@ -20,6 +20,9 @@ quarkus:
       sampler:
         ~: traceidratio
         arg: 0.1
+  vertx:
+    # with loom, 1 event loop is like a poller managing virtual threads
+    event-loops-pool-size: 1
 
 "%prod":
   quarkus:

--- a/quarkus3-virtual/src/main/resources/application.yml
+++ b/quarkus3-virtual/src/main/resources/application.yml
@@ -22,6 +22,7 @@ quarkus:
         arg: 0.1
   vertx:
     # with loom, 1 event loop is like a poller managing virtual threads
+    # See https://github.com/quarkusio/spring-quarkus-perf-comparison/pull/479
     event-loops-pool-size: 1
 
 "%prod":


### PR DESCRIPTION
Change suggested by @franz1981 

Maybe he can explain exactly why this is better when using loom?