### PR TITLE
Add configurable wrk connections and threads to benchmark scripts

### DIFF
--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -48,6 +48,9 @@ states:
   config.repo.branch: main
   config.repo.url: https://github.com/quarkusio/spring-quarkus-perf-comparison.git
 
+  config.wrk.connections: 100
+  config.wrk.threads: 2
+
   config.num_iterations: 3
 
   APP_CMD_PREFIX: taskset --cpu-list ${{config.resources.cpu.app}}
@@ -623,13 +626,13 @@ scripts:
             log_file: ${{LOG_FILE}}
             log_regex: ${{APP_LOG_REGEX}}
         - wait-for: LOG_REGEX_REACHED
-        - sh: ${{RUN.WRK_BIN}} -t 2 -c 100 -d 2m --timeout 2m ${{TARGET_URL}} 2>&1 >${{REPO_DIR}}/logs/wrk-warmup-${{RUNTIMECMD.name}}-${{ITERATION}}.log
+        - sh: ${{RUN.WRK_BIN}} -t ${{config.wrk.threads}} -c ${{config.wrk.connections}} -d 2m --timeout 2m ${{TARGET_URL}} 2>&1 >${{REPO_DIR}}/logs/wrk-warmup-${{RUNTIMECMD.name}}-${{ITERATION}}.log
         - regex: unable to connect
           then:
             - abort: unable to connect to target application
         - sleep: 30s # Wait for the app to complete warmup
         - signal: LOAD_STEADY_STATE_START
-        - sh: ${{RUN.WRK_BIN}} -t 2 -c 100 -d 30s --timeout 30s ${{TARGET_URL}} > ${{REPO_DIR}}/logs/wrk-${{RUNTIMECMD.name}}-${{ITERATION}}.log 2>&1 &
+        - sh: ${{RUN.WRK_BIN}} -t ${{config.wrk.threads}} -c ${{config.wrk.connections}} -d 30s --timeout 30s ${{TARGET_URL}} > ${{REPO_DIR}}/logs/wrk-${{RUNTIMECMD.name}}-${{ITERATION}}.log 2>&1 &
         - sh: WRK_PID=$! && echo $WRK_PID
         - set-state: WRK_PID
         - script:

--- a/scripts/perf-lab/run-benchmarks.sh
+++ b/scripts/perf-lab/run-benchmarks.sh
@@ -101,6 +101,10 @@ help() {
   echo "  --use-container-host-network                            Use host networking instead of port mapping on infra containers"
   echo "  --wait-time <WAIT_TIME>                                 Wait time (in seconds) to wait for things like application startup"
   echo "                                                              Default: ${WAIT_TIME}"
+  echo "  --wrk-connections <WRK_CONNECTIONS>                     Number of wrk connections"
+  echo "                                                              Default: ${WRK_CONNECTIONS}"
+  echo "  --wrk-threads <WRK_THREADS>                             Number of wrk threads"
+  echo "                                                              Default: ${WRK_THREADS}"
 }
 
 exit_abnormal() {
@@ -300,6 +304,8 @@ ${JBANG_CMD} io.hyperfoil.tools:qDup:0.11.0 \
     -S env.run.host.user=${USER} \
     -S env.run.host.target=${target} \
     -S env.run.host.name=${HOST} \
+    -S config.wrk.connections=${WRK_CONNECTIONS} \
+    -S config.wrk.threads=${WRK_THREADS} \
     -S config.num_iterations=${ITERATIONS} \
     -S PROJ_REPO_NAME="$(basename ${SCM_REPO_URL} .git)" \
     -S RUNTIMES="$(make_json_array $RUNTIMES)" \
@@ -349,6 +355,8 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   DROP_OS_FILESYSTEM_CACHES=false
   USE_CONTAINER_HOST_NETWORK=false
   JVM_ARGS=""
+  WRK_CONNECTIONS="100"
+  WRK_THREADS="2"
   EXTRA_QDUP_ARGS=""
   OUTPUT_DIR="/tmp"
 
@@ -531,6 +539,16 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 
       --wait-time)
         WAIT_TIME="$2"
+        shift 2
+        ;;
+
+      --wrk-connections)
+        WRK_CONNECTIONS="$2"
+        shift 2
+        ;;
+
+      --wrk-threads)
+        WRK_THREADS="$2"
         shift 2
         ;;
 


### PR DESCRIPTION
I have used this to run some local scalability tests e.g.

## TPS Scaling Curve

| Conn | Q3-JVM | Q3-Virtual | S4-JVM | S4-Virtual |
|------|--------|------------|--------|------------|
| 1 | 3,132 | 2,744 | 2,206 | 2,035 |
| 2 | 6,014 | 5,060 | 4,373 | 3,865 |
| 3 | 8,241 | 7,069 | 6,354 | 5,728 |
| 4 | 9,234 | 8,165 | 7,542 | 6,650 |
| 5 | 10,286 | 9,798 | 8,219 | 7,839 |
| 10 | 13,517 | 13,122 | 9,834 | 10,738 |
| 50 | 15,765 | 15,298 | 10,536 | 11,826 |
| 100 | 15,690 | 15,041 | 9,901 | 11,103 |

Not sure will survive to #113 ; in case feel free to close it :)