### PR TITLE
Add --profiler-events and --profiler-args options to run-benchmarks.sh

### DIFF
--- a/scripts/perf-lab/helpers/async-profiler.yml
+++ b/scripts/perf-lab/helpers/async-profiler.yml
@@ -40,12 +40,13 @@ scripts:
     - wait-for: ${{wait_start:}} # don't wait by default
     - sleep: ${{delay:0}}
     - sh: >
-        bin/asprof 
-        -d ${{duration:10}} 
-        -f ${{REPO_DIR}}/logs/${{format:flamegraph}}.${{suffix:html}} 
-        -o ${{format:flamegraph}} 
-        -e ${{events:cpu}} 
-        ${{="${{enableTotal : }}".toLowerCase() == "true" ? "--total" : ""}} 
-        --title ${{title:async-profiler}} 
+        bin/asprof
+        -d ${{duration:10}}
+        -f ${{REPO_DIR}}/logs/${{format:flamegraph}}.${{suffix:html}}
+        -o ${{format:flamegraph}}
+        -e ${{events:cpu}}
+        ${{="${{enableTotal : }}".toLowerCase() == "true" ? "--total" : ""}}
+        --title ${{title:async-profiler}}
+        ${{args:}}
         ${{pid}}
     - download: ${{REPO_DIR}}/logs/${{format:flamegraph}}.${{suffix:html}}

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -44,6 +44,7 @@ states:
 
   config.profiler.name: none #jfr syncjfr flamegraph
   config.profiler.events: cpu
+  config.profiler.args:
 
   config.repo.branch: main
   config.repo.url: https://github.com/quarkusio/spring-quarkus-perf-comparison.git
@@ -625,6 +626,7 @@ scripts:
                     suffix: ${{PROFILER_LOGFILE}}
                     format: ${{config.profiler.name}}
                     events: ${{config.profiler.events}}
+                    args: ${{config.profiler.args}}
                     delay: 10s
         - script:
             name: watch-log

--- a/scripts/perf-lab/run-benchmarks.sh
+++ b/scripts/perf-lab/run-benchmarks.sh
@@ -67,6 +67,11 @@ help() {
   echo "                                                              Accepted values: none, jfr, syncjfr, flamegraph"
   echo "                                                              'jfr' and 'flamegraph' use async-profiler. 'syncjfr' uses the built-in JVM Java Flight Recorder (JFR)."
   echo "                                                              Default: ${PROFILER}"
+  echo "  --profiler-args <PROFILER_ARGS>                         Extra arguments to pass to async-profiler (only used with --profiler jfr|flamegraph)"
+  echo "                                                              Example: '--total --alloc 1m'"
+  echo "  --profiler-events <PROFILER_EVENTS>                     Events to pass to async-profiler -e (only used with --profiler jfr|flamegraph)"
+  echo "                                                              Default: ${PROFILER_EVENTS}"
+  echo "                                                              Example: 'wall', 'cpu', 'lock', 'alloc'"
   echo "  --quarkus-build-config-args <QUARKUS_BUILD_CONFIG_ARGS> Quarkus app configuration properties fixed at build time"
   echo "  --quarkus-version <QUARKUS_VERSION>                     The Quarkus version to use"
   echo "                                                              Default: Whatever version is set in pom.xml of the Quarkus app"
@@ -150,6 +155,8 @@ print_values() {
   echo "  NATIVE_SPRING3_BUILD_OPTIONS: $NATIVE_SPRING3_BUILD_OPTIONS"
   echo "  NATIVE_SPRING4_BUILD_OPTIONS: $NATIVE_SPRING4_BUILD_OPTIONS"
   echo "  PROFILER: $PROFILER"
+  echo "  PROFILER_ARGS: $PROFILER_ARGS"
+  echo "  PROFILER_EVENTS: $PROFILER_EVENTS"
   echo "  QUARKUS_BUILD_CONFIG_ARGS: $QUARKUS_BUILD_CONFIG_ARGS"
   echo "  QUARKUS_VERSION: $QUARKUS_VERSION"
   echo "  RUNTIMES: ${RUNTIMES[@]}"
@@ -289,7 +296,8 @@ ${JBANG_CMD} io.hyperfoil.tools:qDup:0.11.0 \
     -S config.quarkus.version=${QUARKUS_VERSION} \
     -S config.springboot3.native_build_options="${NATIVE_SPRING3_BUILD_OPTIONS}" \
     -S config.springboot4.native_build_options="${NATIVE_SPRING4_BUILD_OPTIONS}" \
-    -S config.profiler.events=cpu \
+    -S config.profiler.events="${PROFILER_EVENTS}" \
+    -S config.profiler.args="${PROFILER_ARGS}" \
     -S config.repo.branch=${SCM_REPO_BRANCH} \
     -S config.repo.url=${SCM_REPO_URL} \
     -S config.repo.scenario=${SCENARIO} \
@@ -333,6 +341,8 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   NATIVE_SPRING3_BUILD_OPTIONS=""
   NATIVE_SPRING4_BUILD_OPTIONS=""
   PROFILER="none"
+  PROFILER_ARGS=""
+  PROFILER_EVENTS="cpu"
   QUARKUS_BUILD_CONFIG_ARGS=""
   QUARKUS_VERSION=""
   ALLOWED_RUNTIMES=("quarkus3-jvm" "quarkus3-leyden" "quarkus3-virtual" "quarkus3-virtual-leyden" "quarkus3-native" "spring3-jvm" "spring3-leyden" "spring3-virtual" "spring3-virtual-leyden" "spring3-jvm-aot" "spring3-native" "spring4-jvm" "spring4-leyden" "spring4-virtual" "spring4-virtual-leyden" "spring4-jvm-aot" "spring4-native")
@@ -457,6 +467,16 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
           echo "!! [ERROR] --profiler option must be one of (none, jfr, syncjfr, flamegraph)!!"
           exit_abnormal
         fi
+        shift 2
+        ;;
+
+      --profiler-args)
+        PROFILER_ARGS="$2"
+        shift 2
+        ;;
+
+      --profiler-events)
+        PROFILER_EVENTS="$2"
         shift 2
         ;;
 

--- a/scripts/perf-lab/run-benchmarks.sh
+++ b/scripts/perf-lab/run-benchmarks.sh
@@ -68,6 +68,11 @@ help() {
   echo "                                                              Accepted values: none, jfr, syncjfr, flamegraph"
   echo "                                                              'jfr' and 'flamegraph' use async-profiler. 'syncjfr' uses the built-in JVM Java Flight Recorder (JFR)."
   echo "                                                              Default: ${PROFILER}"
+  echo "  --profiler-args <PROFILER_ARGS>                         Extra arguments to pass to async-profiler (only used with --profiler jfr|flamegraph)"
+  echo "                                                              Example: '--total --alloc 1m'"
+  echo "  --profiler-events <PROFILER_EVENTS>                     Events to pass to async-profiler -e (only used with --profiler jfr|flamegraph)"
+  echo "                                                              Default: ${PROFILER_EVENTS}"
+  echo "                                                              Example: 'wall', 'cpu', 'lock', 'alloc'"
   echo "  --quarkus-build-config-args <QUARKUS_BUILD_CONFIG_ARGS> Quarkus app configuration properties fixed at build time"
   echo "  --quarkus-version <QUARKUS_VERSION>                     The Quarkus version to use"
   echo "                                                              Default: Whatever version is set in pom.xml of the Quarkus app"
@@ -151,6 +156,8 @@ print_values() {
   echo "  NATIVE_SPRING3_BUILD_OPTIONS: $NATIVE_SPRING3_BUILD_OPTIONS"
   echo "  NATIVE_SPRING4_BUILD_OPTIONS: $NATIVE_SPRING4_BUILD_OPTIONS"
   echo "  PROFILER: $PROFILER"
+  echo "  PROFILER_ARGS: $PROFILER_ARGS"
+  echo "  PROFILER_EVENTS: $PROFILER_EVENTS"
   echo "  QUARKUS_BUILD_CONFIG_ARGS: $QUARKUS_BUILD_CONFIG_ARGS"
   echo "  QUARKUS_VERSION: $QUARKUS_VERSION"
   echo "  RUNTIMES: ${RUNTIMES[@]}"
@@ -290,7 +297,8 @@ ${JBANG_CMD} io.hyperfoil.tools:qDup:0.11.2 \
     -S config.quarkus.version=${QUARKUS_VERSION} \
     -S config.springboot3.native_build_options="${NATIVE_SPRING3_BUILD_OPTIONS}" \
     -S config.springboot4.native_build_options="${NATIVE_SPRING4_BUILD_OPTIONS}" \
-    -S config.profiler.events=cpu \
+    -S config.profiler.events="${PROFILER_EVENTS}" \
+    -S config.profiler.args="${PROFILER_ARGS}" \
     -S config.repo.branch=${SCM_REPO_BRANCH} \
     -S config.repo.url=${SCM_REPO_URL} \
     -S config.repo.scenario=${SCENARIO} \
@@ -334,6 +342,8 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   NATIVE_SPRING3_BUILD_OPTIONS=""
   NATIVE_SPRING4_BUILD_OPTIONS=""
   PROFILER="none"
+  PROFILER_ARGS=""
+  PROFILER_EVENTS="cpu"
   QUARKUS_BUILD_CONFIG_ARGS=""
   QUARKUS_VERSION=""
   ALLOWED_RUNTIMES=("quarkus3-jvm" "quarkus3-leyden" "quarkus3-virtual" "quarkus3-virtual-leyden" "quarkus3-native" "spring3-jvm" "spring3-leyden" "spring3-virtual" "spring3-virtual-leyden" "spring3-jvm-aot" "spring3-native" "spring4-jvm" "spring4-leyden" "spring4-virtual" "spring4-virtual-leyden" "spring4-jvm-aot" "spring4-native")
@@ -458,6 +468,16 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
           echo "!! [ERROR] --profiler option must be one of (none, jfr, syncjfr, flamegraph)!!"
           exit_abnormal
         fi
+        shift 2
+        ;;
+
+      --profiler-args)
+        PROFILER_ARGS="$2"
+        shift 2
+        ;;
+
+      --profiler-events)
+        PROFILER_EVENTS="$2"
         shift 2
         ;;
 


### PR DESCRIPTION
Expose async-profiler event type and extra arguments as CLI options instead of hardcoding 'cpu'. This allows profiling for different event types (wall, lock, alloc) or passing extra asprof flags (--total, etc) without needing --extra-qdup-args.

Closes #377

This will prove useful to validate why, in the perf lab, Spring is suffering from a huge amount of non-voluntary context switch .e.g by using `-e context-switches` - see https://stackoverflow.com/a/64404504 (no need to specify the interval anymore, it's now 2 OOTB).
Just as a note for myself of the future: it was needed 2 because async-profiler's context switch event emission can generate an interrupt which can temporarly awake a parked OS thread, which will likely park again, right after, doubling effectively the number of context switches.