### PR TITLE
Add .NET 10 / ASP.NET Core 10 implementation and perf-lab integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,3 +186,39 @@ jobs:
         run: |
           ../scripts/stress.sh "${{ matrix.app.app-jar }}"
           ../scripts/1strequest.sh "java -XX:ActiveProcessorCount=4 -Xms512m -Xmx512m ${{ matrix.app.run-args }} -jar ${{ matrix.app.app-jar }}" 3
+
+
+  dotnet-build-test:
+    runs-on: ubuntu-latest
+    name: "[dotnet-build-test]"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
+
+      - name: Build and test (unit tests only)
+        working-directory: dotnet10
+        # E2E tests require a running PostgreSQL instance with seed data.
+        # See DOTNET-PORTING.md for options to enable them in CI.
+        run: dotnet test --filter "FullyQualifiedName!~Dotnet10.Tests.E2e"
+
+      - name: Publish
+        working-directory: dotnet10
+        run: dotnet publish Dotnet10 -c Release -o publish
+
+      - name: Setup JBang
+        uses: jbangdev/setup-jbang@main
+
+      - name: Validate simple scripts
+        run: |
+          scripts/stress.sh dotnet10/publish/dotnet10
+          scripts/1strequest.sh "dotnet10/publish/dotnet10" 5

--- a/.github/workflows/syncbot.yml
+++ b/.github/workflows/syncbot.yml
@@ -147,8 +147,7 @@ jobs:
           fi
 
       - name: Update PR comment on success
-        if: steps.push-and-pr.outputs.push_failed_workflows != 'true' && steps.cherry-pick.outputs.skipped_commits == ''
-        if: steps.cherry-pick.outputs.all_skipped != 'true' && steps.cherry-pick.outputs.skipped_commits == ''
+        if: steps.push-and-pr.outputs.push_failed_workflows != 'true' && steps.cherry-pick.outputs.all_skipped != 'true' && steps.cherry-pick.outputs.skipped_commits == ''
         uses: quarkusio/action-helpers@main
         with:
           action: maintain-one-comment

--- a/DOTNET-PORTING.md
+++ b/DOTNET-PORTING.md
@@ -1,0 +1,208 @@
+# dotnet Port — TODO
+
+This file tracks the integration work for the dotnet implementation and serves as the
+canonical checklist for adding future dotnet versions.
+
+## Quarkus → dotnet10 Concept Mapping
+
+| Concept | Quarkus 3 | dotnet10 |
+|---|---|---|
+| **HTTP framework** | RESTEasy (JAX-RS `@Path`, `@GET`) | ASP.NET Core Minimal API (`app.MapGet`) |
+| **DI container** | CDI (`@ApplicationScoped`, `@Inject`) | `IServiceCollection` (`AddScoped`, constructor injection) |
+| **ORM** | Hibernate ORM Panache (`PanacheEntityBase`) | EF Core (`DbContext`, `DbSet<T>`) |
+| **DB driver** | `quarkus-jdbc-postgresql` | Npgsql (`Npgsql.EntityFrameworkCore.PostgreSQL`) |
+| **Connection pool** | Agroal (built into Quarkus datasource) | EF Core connection pool (Npgsql default) |
+| **Health checks** | SmallRye Health (`/health/live`, `/health/ready`) | `AddHealthChecks().AddDbContextCheck<T>()` |
+| **Metrics** | Micrometer → OTel OTLP | OTel `WithMetrics` → OTLP (ASP.NET Core + runtime meters) |
+| **Traces** | SmallRye OTel, `traceidratio 0.1` | OTel `TraceIdRatioBasedSampler(0.1)` + `AddAspNetCoreInstrumentation()` |
+| **Logs** | OTel OTLP (`otel.logs.enabled: true`) | *(not yet wired — `UseOtlpExporter()` API gap in 1.11)* |
+| **OTel exporter** | OTLP gRPC `localhost:4317` | OTLP gRPC `localhost:4317` (same default) |
+| **JSON serialization** | Jackson (via `quarkus-rest-jackson`) | `System.Text.Json` with source-generated `FruitJsonContext` |
+| **Serialization optimization** | Reflection-free serializers (`enable-reflection-free-serializers: true`) | Source-generated context (`TypeInfoResolverChain`) — AOT-safe by design |
+| **Config format** | `application.yml` | `appsettings.json` / env vars / `builder.Configuration` |
+| **HTTP port** | 8080 (Quarkus default) | 8080 (explicit `UseUrls("http://0.0.0.0:8080")`) |
+| **Build output** | `quarkus-run.jar` (fast-jar) | Self-contained binary via `dotnet publish -c Release` |
+| **Native image** | GraalVM (`-Pnative`) — production-ready | `PublishAot` — blocked (see Native AOT section) |
+| **Test framework** | JUnit 5 + REST Assured + Quarkus DevServices | xUnit + `WebApplicationFactory` + Testcontainers |
+| **DB for tests** | Quarkus DevServices (auto-spins PostgreSQL) | Testcontainers (E2E) / mocked repos (unit) |
+| **Startup log** | `quarkus3 started in Xs` (built-in) | Custom `ApplicationStarted` callback emitting same pattern |
+| **CPU pinning** | `taskset --cpu-list 0-3` via `APP_CMD_PREFIX` | Same `APP_CMD_PREFIX` prepended to `runCmd` in `main.yml` |
+| **Memory limit** | `-Xmx512m` via `--jvm-memory` → `config.jvm.memory` | `DOTNET_GCHeapHardLimit` computed from `--jvm-memory` by `xmx_to_dotnet_gc_limit()` in `run-benchmarks.sh` → `config.dotnet.gcHeapHardLimit` |
+| **Processor count** | JVM infers from `taskset` cores | `DOTNET_ProcessorCount` set to `config.resources.app_cpus` (count derived from `--cpus-app`) |
+| **GC mode** | Server GC (JVM default for server workloads) | `DOTNET_gcServer=1` |
+
+## dotnet10 — Status
+
+### Done ✓
+
+- [x] ASP.NET Core 10 implementation equivalent to the plain Quarkus version
+- [x] `scripts/stress.sh` detects dotnet binaries and sets correct runtime env vars
+- [x] `scripts/1strequest.sh` detects dotnet binaries and sets correct runtime env vars
+- [x] `scripts/perf-lab/main.yml` — `dotnet10` entry in `RUNTIMES` and `RUNTIMECMDS`; `updateScript: skip-version-update` prevents abort when qDup's `update-runtime-version` runs
+- [x] `scripts/perf-lab/run-benchmarks.sh` — `dotnet10` in `ALLOWED_RUNTIMES`
+- [x] `scripts/perf-lab/helpers/dotnet.yml` — `ensure-dotnet` requirement check
+- [x] `scripts/perf-lab/helpers/requirements.yml` — `ensure-dotnet` wired into `ensure-requirements`
+- [x] `dotnet10/README.md` documents how to run the dotnet app locally
+- [x] `Program.cs` emits a startup log matching the perf-lab `logFileStartedRegex`
+- [x] `scripts/remote-setup.sh` — one-command remote host preparation (SSH key install, passwordless sudo, environment verification)
+- [x] `README.md` — "Better: Run on a dedicated remote Linux box" section with 3-step workflow and `--repo-url` guidance for local changes
+- [x] perf-lab runtime constraints made fair — `main.yml` `runCmd` adds CPU pinning (`taskset` via `APP_CMD_PREFIX`), `DOTNET_gcServer=1`, and `DOTNET_ProcessorCount` from `config.resources.app_cpus`; `DOTNET_GCHeapHardLimit` is computed from `--jvm-memory` via `xmx_to_dotnet_gc_limit()` in `run-benchmarks.sh` so memory limits always match the JVM constraint
+
+### Remaining / Open
+
+- [ ] **E2E tests need a running database in CI.**
+  The unit tests (`Dotnet10.Tests.Service.*`) run fine without infrastructure.
+  The E2E tests (`Dotnet10.Tests.E2e.*`) require PostgreSQL with seed data.
+  Current CI job excludes E2E tests with `--filter "FullyQualifiedName!~Dotnet10.Tests.E2e"`.
+  Options:
+  - Add Testcontainers (`Testcontainers.PostgreSql`) to `Dotnet10.Tests` so E2E tests
+    spin up their own database, matching how Quarkus DevServices works for the JVM jobs.
+  - Or start `ghcr.io/quarkusio/postgres-17-perf:main` as a GitHub Actions service
+    container and remove the filter.
+
+- [ ] **Dependabot NuGet monitoring.**
+  `.github/dependabot.yml` only covers Maven (`package-ecosystem: maven`).
+  Add a second entry for `nuget` pointing at `dotnet10/`.
+
+- [ ] **perf-lab: `java -version` calls are misleading for dotnet runtimes.**
+  `measure-build-times`, `measure-time-to-first-request`, and `measure-rss`
+  all call `sh: java -version` unconditionally. For dotnet this is harmless noise (Java is
+  always present because qDup itself is a Java tool), but it clutters the output.
+  Consider making the call conditional on `${{RUNTIME.type}} != dotnet`.
+  (`test-build` was removed from the allowed tests in the upstream refactor, so it is no
+  longer a concern.)
+
+- [ ] **perf-lab: no `--dotnet-version` selection support.** ⚠️ Hard
+  `run-benchmarks.sh` lets you pin `--quarkus-version` and `--springboot3/4-version` because
+  those are Maven dependency versions overridden at build time with a single property. The .NET
+  SDK version is fundamentally different: it is an OS-level installation, not a project
+  dependency. Whatever `dotnet` binary is on the `PATH` is what gets used, and `ensure-dotnet`
+  in `helpers/dotnet.yml` merely logs it without any selection logic.
+  To add proper version selection the following would all be needed:
+  - Teach `helpers/dotnet.yml` to download and invoke Microsoft's `dotnet-install.sh` for a
+    specific SDK version (mirroring how `ensure-java` / `ensure-graalvm` delegate to SDKMAN).
+  - Add a `--dotnet-version` flag to `run-benchmarks.sh` and wire it through to a new qDup
+    state variable (e.g. `config.dotnet.version`).
+  - Handle SDK activation on the remote host — unlike SDKMAN's `sdk use`, the .NET SDK uses
+    `global.json` or environment variables (`DOTNET_ROOT`, `PATH` prepending) to select a
+    version, which must persist across the separate SSH commands qDup issues.
+  - Decide whether to install into a shared location or a per-run sandbox to avoid races if
+    benchmarks are ever run in parallel.
+
+- [ ] **perf-lab: no dotnet profiling support.**
+  The JVM runtimes can use async-profiler (JFR / flamegraph). dotnet has equivalent tools:
+  `dotnet-trace` (CPU samples → speedscope / chromium), `dotnet-counters`, and Linux `perf`.
+  A `scripts/perf-lab/helpers/dotnet-trace.yml` helper could mirror `async-profiler.yml`.
+
+- [ ] **dotnet-native: not feasible yet.** ⛔ Blocked by Microsoft
+  A `dotnet10-native` runtime (analogous to `quarkus3-native` / `spring3-native`) cannot be
+  added in a like-for-like way with the current application stack. The blockers are fundamental,
+  not configuration issues:
+
+  **Why it doesn't work today:**
+  - **EF Core**: Query compilation relies on expression trees and reflection that are built and
+    evaluated at runtime. Native AOT trims this code away. As of .NET 10, EF Core's Native AOT
+    support is still marked experimental and requires switching to interceptors (compile-time
+    query pre-compilation via `dotnet ef dbcontext optimize`), which is a significant
+    architectural change not present in the Quarkus or Spring implementations.
+  - **Npgsql**: Requires explicit compile-time registration of all mapped CLR types
+    (`NpgsqlDataSourceBuilder.EnableDynamicJson()` is not AOT-safe). Entity mappings, enum
+    converters, and range types must all be declared upfront.
+  - **Serialization edge cases**: Even with the source-generated `FruitJsonContext` already in
+    place, generic collections and nested DTOs can still fail at runtime because the AOT
+    trimmer's static analysis misses types that are only referenced through EF Core's
+    internal materializer.
+  - **No equivalent of Quarkus build-time extensions**: Quarkus has spent years solving these
+    exact problems for Hibernate and Jackson via build-time bytecode generation and
+    `@RegisterForReflection`. The .NET ecosystem has no equivalent tooling depth yet.
+
+  **What would need to be true before adding `dotnet10-native`:**
+  - EF Core Native AOT support reaches stable/non-experimental status (tracked in
+    [dotnet/efcore#29840](https://github.com/dotnet/efcore/issues/29840))
+  - `dotnet ef dbcontext optimize` (compiled query interceptors) works correctly with Npgsql
+    without requiring application code changes beyond what Quarkus needs
+  - The published binary produces identical HTTP behaviour to the JIT version under load
+    (no trimming-related `NullReferenceException` or `MissingMethodException` at runtime)
+  - Verified by running the full perf-lab test suite without errors across all 3 iterations
+
+  **Checklist for when the above is met:**
+  - [ ] Run `dotnet ef dbcontext optimize` and commit the generated interceptors
+  - [ ] Add `<PublishAot>true</PublishAot>` and `<TrimmerRootDescriptor>` to `Dotnet10.csproj`
+  - [ ] Register all Npgsql type mappings explicitly in `Program.cs`
+  - [ ] Add `dotnet10-native` RUNTIMECMD to `main.yml` (same pattern as `quarkus3-native` /
+    `spring3-native`, with `buildCmd: "dotnet publish Dotnet10 -c Release -r linux-x64 -o publish"`)
+  - [ ] Add `dotnet10-native` to `ALLOWED_RUNTIMES` and `DEFAULT_RUNTIMES` in `run-benchmarks.sh`
+  - [ ] Add a `dotnet10-native-build-test` CI job
+  - [ ] Run perf-lab end-to-end and confirm zero errors across all iterations before merging
+
+## Adding a Future dotnet Version (e.g., dotnet11)
+
+Every new major dotnet version needs changes in exactly these places.
+Work through the checklist top-to-bottom.
+
+### 1. New application directory
+
+```
+cp -r dotnet10 dotnet11
+```
+
+Inside `dotnet11/`:
+- [ ] Rename solution and project files:
+  `Dotnet10.sln` → `Dotnet11.sln`, `Dotnet10/` → `Dotnet11/`, `Dotnet10.Tests/` → `Dotnet11.Tests/`
+- [ ] Update `<TargetFramework>net10.0</TargetFramework>` → `net11.0` in both `.csproj` files
+- [ ] Update all NuGet package versions to their dotnet 11–compatible releases
+- [ ] Replace every occurrence of `dotnet10` / `Dotnet10` in source files and namespaces
+  with `dotnet11` / `Dotnet11` (including the startup log message in `Program.cs`)
+- [ ] Update `dotnet11/README.md`
+
+### 2. `scripts/perf-lab/main.yml`
+
+- [ ] Add `dotnet11` to the `RUNTIMES` list (line ~62)
+- [ ] Add a `RUNTIMECMDS` entry (copy from `dotnet10`, update name, dir, and regex):
+  ```yaml
+  - name: dotnet11
+    type: dotnet
+    dir: ${{DOTNET11_DIR}}
+    updateScript: skip-version-update
+    buildCmd: "dotnet publish Dotnet11 -c Release -o publish"
+    runCmd: "./publish/dotnet11"
+    logFileStartedRegex: ".*dotnet11.+started in.*"
+  ```
+- [ ] Add `update-state` entry (note: use `${{PROJ_REPO_DIR}}`, not `${{REPO_DIR}}/${{PROJ_REPO_NAME}}`):
+  ```yaml
+  - set-state: RUN.DOTNET11_DIR ${{PROJ_REPO_DIR}}/dotnet11
+  ```
+- [ ] Add `output-vars` log line for `DOTNET11_DIR`
+
+### 3. `scripts/perf-lab/run-benchmarks.sh`
+
+- [ ] Add `dotnet11` to `ALLOWED_RUNTIMES` array (line ~338) and `DEFAULT_RUNTIMES` array (line ~339)
+- [ ] Add `dotnet11` to the `--runtimes` help text (line ~79)
+
+### 4. `.github/workflows/main.yml`
+
+- [ ] Add a `dotnet11-build-test` job (copy `dotnet-build-test`, change SDK version to
+  `11.x` and working-directory to `dotnet11`)
+
+### 5. `README.md`
+
+- [ ] Add `dotnet11` entry to "What's in the repo"
+- [ ] Add `stress.sh` / `1strequest.sh` examples for dotnet11
+
+### 6. `scripts/perf-lab/helpers/dotnet.yml`
+
+No change needed — `ensure-dotnet` already checks the generic `dotnet --version`,
+which satisfies any installed SDK version.
+
+If the benchmark environment must pin to a specific SDK version (e.g. to prevent a newer
+SDK from silently changing compiler behaviour), add a version-pinned variant:
+```yaml
+ensure-dotnet11:
+  - log: Checking for .NET 11 SDK
+  - sh: dotnet --version | grep -E '^11\.'
+```
+and wire it into `requirements.yml` instead of (or alongside) `ensure-dotnet`.
+
+### 7. Dependabot
+
+- [ ] Add a third `updates` entry in `.github/dependabot.yml` for the new directory.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ This project contains the following modules:
     - A Quarkus 3.x version of the application using Virtual Threads
 - [quarkus3-spring-compatibility](quarkus3-spring-compatibility)
     - A Quarkus 3.x version of the application using the Spring compatibility layer. You can also recreate this application from the spring application using [a few manual steps](spring-conversion.md).
+- [dotnet10](dotnet10)
+    - An ASP.NET Core 10 (.NET 10) version of the application, equivalent to the plain Quarkus implementation.
  
 ## Architecture & Workflow
 
@@ -95,6 +97,8 @@ cd scripts
 ## Scripts
 
 There are some [scripts](scripts) available to help you run the application:
+- [`remote-setup.sh`](scripts/remote-setup.sh)
+    - Prepares a remote Linux host for benchmark runs: installs your SSH key, configures passwordless sudo, and verifies the environment — without requiring you to log into the box directly. See [Running on a remote Linux box](#better-run-on-a-dedicated-remote-linux-box) for the full workflow.
 - [`run-requests.sh`](scripts/run-requests.sh)
     - Runs a set of requests against a running application.
 - [`infra.sh`](scripts/infra.sh)
@@ -135,6 +139,13 @@ scripts/stress.sh quarkus3-spring-compatibility/target/quarkus-app/quarkus-run.j
 scripts/stress.sh springboot3/target/springboot3.jar
 ```
 
+For .NET, pass the path to the published binary directly (no `java` wrapper needed):
+
+```shell
+# First publish: cd dotnet10 && dotnet publish Dotnet10 -c Release -o publish
+scripts/stress.sh dotnet10/publish/dotnet10
+```
+
 For each test, you should see output like 
 
 ```shell
@@ -153,6 +164,12 @@ For example,
 scripts/1strequest.sh "java -XX:ActiveProcessorCount=8 -Xms512m -Xmx512m -jar quarkus3/target/quarkus-app/quarkus-run.jar" 5
 scripts/1strequest.sh "java -XX:ActiveProcessorCount=8 -Xms512m -Xmx512m -jar quarkus3-spring-compatibility/target/quarkus-app/quarkus-run.jar" 5
 scripts/1strequest.sh "java -XX:ActiveProcessorCount=8 -Xms512m -Xmx512m -jar springboot3/target/springboot3.jar" 5
+```
+
+For .NET:
+
+```shell
+scripts/1strequest.sh "dotnet10/publish/dotnet10" 5
 ```
 
 You should see output like 
@@ -190,6 +207,73 @@ To explore all available options (including the full list of runtimes and tests)
 ```
 
 To produce charts from the output, you can use the scripts at https://github.com/quarkusio/benchmarks.
+
+### Better: Run on a dedicated remote Linux box
+
+Running on a separate Linux machine removes the biggest sources of noise from the "single machine" approach: your load generator no longer competes with the application under test, and you get a stable, server-class CPU without laptop power management interfering.
+
+All steps are driven from **your local machine** — you never need to log into the remote box and do some manual configuration.
+
+
+#### Step 1 — Have a Linux box ready
+
+The remote host must:
+- Run Linux
+- Be reachable by SSH from your machine
+- Have **outbound internet access** so qDup can download Java, GraalVM, jbang, and the repo during the benchmark setup phase
+- Have at least **14 CPU cores** for proper workload isolation — the benchmark pins each role to dedicated cores:
+
+  | Role | Default cores | Count |
+  |---|---|---|
+  | Application under test | `0-3` | 4 |
+  | PostgreSQL database | `4-6` | 3 |
+  | OpenTelemetry stack | `7-9` | 3 |
+  | Load generator | `10-12` | 3 |
+  | Monitoring | `13` | 1 |
+  | Time-to-first-request | `10` | (shared with load gen) |
+
+  Use `--cpus-app`, `--cpus-db`, `--cpus-otel`, `--cpus-load-gen`, `--cpus-monitoring`, and `--cpus-first-request` to override the defaults if your CPU layout differs (e.g. to stay within a single NUMA node).
+
+#### Step 2 — Run the remote setup script
+
+[`scripts/remote-setup.sh`](scripts/remote-setup.sh) configures the host in one command: it installs your SSH public key (prompts for the remote password once), sets up passwordless sudo (prompts for the sudo password once), and verifies the environment.
+
+```shell
+scripts/remote-setup.sh --host <HOST> --user <USER>
+```
+
+After this you will never need a password to reach the box again. Run with `--help` to see all options (custom SSH key, non-standard port, check-only mode, etc.).
+
+#### Step 3 — Run the benchmarks
+
+From the `scripts/perf-lab/` directory:
+
+```shell
+./run-benchmarks.sh \
+  --host <HOST> \
+  --user <USER> \
+  --quarkus-version 3.28.4 \
+  --springboot3-version 3.5.6
+```
+
+qDup will SSH into the box, install all required tooling (Java, GraalVM, jbang, .NET SDK, …), clone the repository, build each runtime, and run all tests — all without any manual intervention.
+
+> [!IMPORTANT]
+> `run-benchmarks.sh` always clones the repository from GitHub (the URL passed via `--repo-url`, defaulting to the upstream repo). **Local uncommitted changes are not picked up automatically.**
+>
+> If you have modified application code (e.g. `dotnet10/Dotnet10/Program.cs`) and want those changes benchmarked, commit and push them first, then point the script at your fork/branch:
+>
+> ```shell
+> git add dotnet10/Dotnet10/Program.cs && git commit -m "my changes" && git push origin my-branch
+>
+> ./run-benchmarks.sh \
+>   --host <HOST> \
+>   --user <USER> \
+>   --repo-url https://github.com/<YOUR_FORK>/spring-quarkus-perf-comparison.git \
+>   --repo-branch my-branch \
+>   --quarkus-version 3.28.4 \
+>   --springboot3-version 3.5.6
+> ```
 
 ### The best: Run tests in a controlled lab
 

--- a/dotnet10/.gitignore
+++ b/dotnet10/.gitignore
@@ -1,0 +1,25 @@
+## .NET
+bin/
+obj/
+publish/
+*.user
+.vs/
+.vscode/
+*.suo
+*.userprefs
+
+## Rider / JetBrains
+.idea/
+
+## Test results
+TestResults/
+coverage*/
+
+## NuGet
+*.nupkg
+.nuget/
+packages/
+
+## OS
+.DS_Store
+Thumbs.db

--- a/dotnet10/Dotnet10.Tests/Dotnet10.Tests.csproj
+++ b/dotnet10/Dotnet10.Tests/Dotnet10.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      xunit.v3 targets net8.0, which net10.0 resolves correctly.
+      xunit 2.x targets net6.0 and fails at runtime on net10.0.
+      Microsoft.NET.Test.Sdk is required for dotnet test / VSTest integration.
+    -->
+    <PackageReference Include="Microsoft.NET.Test.Sdk"    Version="17.13.0" />
+    <PackageReference Include="xunit.v3"                  Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dotnet10\Dotnet10.csproj"
+                      ExcludeAssets="runtime" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet10/Dotnet10.Tests/E2e/FruitControllerEndToEndTest.cs
+++ b/dotnet10/Dotnet10.Tests/E2e/FruitControllerEndToEndTest.cs
@@ -1,0 +1,198 @@
+using System.Net;
+using System.Net.Http.Json;
+using Dotnet10.Dto;
+using Xunit;
+
+namespace Dotnet10.Tests.E2e;
+
+/// <summary>
+/// End-to-end tests that exercise the running application over HTTP.
+///
+/// Equivalent to @QuarkusIntegrationTest FruitControllerIT in the Quarkus project:
+/// the application runs as a separate process and the tests call it via plain HTTP.
+///
+/// Prerequisites:
+///   1. PostgreSQL running on localhost:5432 (database: fruits, user: fruits, password: fruits)
+///   2. Database seeded from import.sql
+///   3. Application running: dotnet run --project Dotnet10 -c Release
+///
+/// All tests are fully independent and require no ordering.
+/// AddFruit captures the count before and after, so it is safe to run in any order.
+/// </summary>
+public class FruitControllerEndToEndTest : IDisposable
+{
+    private readonly HttpClient _client = new() { BaseAddress = new Uri("http://localhost:8080") };
+
+    public void Dispose() => _client.Dispose();
+
+    [Fact]
+    public async Task GetAll()
+    {
+        var response = await _client.GetAsync("/fruits", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var fruits = await response.Content.ReadFromJsonAsync<List<FruitDto>>(TestContext.Current.CancellationToken);
+        Assert.NotNull(fruits);
+        Assert.True(fruits.Count >= 10);
+
+        // Apple is always first (ordered by ID, seeded first)
+        var apple = fruits.First(f => f.Name == "Apple");
+        Assert.Equal("Hearty fruit", apple.Description);
+        Assert.Equal(1.29f,      apple.StorePrices![0].Price);
+        Assert.Equal("Store 1",      apple.StorePrices[0].Store.Name);
+        Assert.Equal("123 Main St",  apple.StorePrices[0].Store.Address!.Address);
+        Assert.Equal("Anytown",      apple.StorePrices[0].Store.Address!.City);
+        Assert.Equal("USA",          apple.StorePrices[0].Store.Address!.Country);
+        Assert.Equal("USD",          apple.StorePrices[0].Store.Currency);
+        Assert.Equal(2.49f,      apple.StorePrices[1].Price);
+        Assert.Equal("Store 2",      apple.StorePrices[1].Store.Name);
+        Assert.Equal("456 Main St",  apple.StorePrices[1].Store.Address!.Address);
+        Assert.Equal("Paris",        apple.StorePrices[1].Store.Address!.City);
+        Assert.Equal("France",       apple.StorePrices[1].Store.Address!.Country);
+        Assert.Equal("EUR",          apple.StorePrices[1].Store.Currency);
+
+        var pear = fruits.First(f => f.Name == "Pear");
+        Assert.Equal("Juicy fruit", pear.Description);
+        Assert.Equal(0.99f, pear.StorePrices![0].Price);
+        Assert.Equal("Store 1", pear.StorePrices[0].Store.Name);
+        Assert.Equal(1.19f, pear.StorePrices[1].Price);
+        Assert.Equal("Store 2", pear.StorePrices[1].Store.Name);
+
+        var banana = fruits.First(f => f.Name == "Banana");
+        Assert.Equal("Tropical yellow fruit", banana.Description);
+        Assert.Equal(0.59f, banana.StorePrices![0].Price);
+        Assert.Equal("Store 1", banana.StorePrices[0].Store.Name);
+        Assert.Equal(0.89f, banana.StorePrices[1].Price);
+        Assert.Equal("Store 2", banana.StorePrices[1].Store.Name);
+
+        var orange = fruits.First(f => f.Name == "Orange");
+        Assert.Equal("Citrus fruit rich in vitamin C", orange.Description);
+        Assert.Equal(1.19f, orange.StorePrices![0].Price);
+        Assert.Equal("Store 1", orange.StorePrices[0].Store.Name);
+        Assert.Equal(1.79f, orange.StorePrices[1].Price);
+        Assert.Equal("Store 2", orange.StorePrices[1].Store.Name);
+
+        var strawberry = fruits.First(f => f.Name == "Strawberry");
+        Assert.Equal("Sweet red berry", strawberry.Description);
+        Assert.Equal(3.99f, strawberry.StorePrices![0].Price);
+        Assert.Equal("Store 1",     strawberry.StorePrices[0].Store.Name);
+        Assert.Equal(3.49f, strawberry.StorePrices[1].Price);
+        Assert.Equal("Store 3",     strawberry.StorePrices[1].Store.Name);
+        Assert.Equal("789 Oak Ave", strawberry.StorePrices[1].Store.Address!.Address);
+        Assert.Equal("London",      strawberry.StorePrices[1].Store.Address!.City);
+        Assert.Equal("UK",          strawberry.StorePrices[1].Store.Address!.Country);
+        Assert.Equal("GBP",         strawberry.StorePrices[1].Store.Currency);
+
+        var mango = fruits.First(f => f.Name == "Mango");
+        Assert.Equal("Exotic tropical fruit", mango.Description);
+        Assert.Equal(2.99f, mango.StorePrices![0].Price);
+        Assert.Equal("Store 2", mango.StorePrices[0].Store.Name);
+        Assert.Equal(3.99f, mango.StorePrices[1].Price);
+        Assert.Equal("Store 6",    mango.StorePrices[1].Store.Name);
+        Assert.Equal("888 Pine St", mango.StorePrices[1].Store.Address!.Address);
+        Assert.Equal("Sydney",     mango.StorePrices[1].Store.Address!.City);
+        Assert.Equal("Australia",  mango.StorePrices[1].Store.Address!.Country);
+        Assert.Equal("AUD",        mango.StorePrices[1].Store.Currency);
+
+        var grape = fruits.First(f => f.Name == "Grape");
+        Assert.Equal("Small purple or green fruit", grape.Description);
+        Assert.Equal(2.79f, grape.StorePrices![0].Price);
+        Assert.Equal("Store 3",   grape.StorePrices[0].Store.Name);
+        Assert.Equal(2.49f, grape.StorePrices[1].Price);
+        Assert.Equal("Store 7",   grape.StorePrices[1].Store.Name);
+        Assert.Equal("999 Elm Rd", grape.StorePrices[1].Store.Address!.Address);
+        Assert.Equal("Berlin",    grape.StorePrices[1].Store.Address!.City);
+        Assert.Equal("Germany",   grape.StorePrices[1].Store.Address!.Country);
+        Assert.Equal("EUR",       grape.StorePrices[1].Store.Currency);
+
+        var pineapple = fruits.First(f => f.Name == "Pineapple");
+        Assert.Equal("Large tropical fruit", pineapple.Description);
+        Assert.Equal(599.99f, pineapple.StorePrices![0].Price);
+        Assert.Equal("Store 4",       pineapple.StorePrices[0].Store.Name);
+        Assert.Equal("321 Cherry Ln", pineapple.StorePrices[0].Store.Address!.Address);
+        Assert.Equal("Tokyo",         pineapple.StorePrices[0].Store.Address!.City);
+        Assert.Equal("Japan",         pineapple.StorePrices[0].Store.Address!.Country);
+        Assert.Equal("JPY",           pineapple.StorePrices[0].Store.Currency);
+        Assert.Equal(5.49f,  pineapple.StorePrices[1].Price);
+        Assert.Equal("Store 6", pineapple.StorePrices[1].Store.Name);
+        Assert.Equal(49.99f,  pineapple.StorePrices[2].Price);
+        Assert.Equal("Store 8",        pineapple.StorePrices[2].Store.Name);
+        Assert.Equal("147 Birch Blvd", pineapple.StorePrices[2].Store.Address!.Address);
+        Assert.Equal("Mexico City",    pineapple.StorePrices[2].Store.Address!.City);
+        Assert.Equal("Mexico",         pineapple.StorePrices[2].Store.Address!.Country);
+        Assert.Equal("MXN",            pineapple.StorePrices[2].Store.Currency);
+
+        var watermelon = fruits.First(f => f.Name == "Watermelon");
+        Assert.Equal("Large refreshing summer fruit", watermelon.Description);
+        Assert.Equal(6.99f, watermelon.StorePrices![0].Price);
+        Assert.Equal("Store 5",    watermelon.StorePrices[0].Store.Name);
+        Assert.Equal("555 Maple Dr", watermelon.StorePrices[0].Store.Address!.Address);
+        Assert.Equal("Toronto",    watermelon.StorePrices[0].Store.Address!.City);
+        Assert.Equal("Canada",     watermelon.StorePrices[0].Store.Address!.Country);
+        Assert.Equal("CAD",        watermelon.StorePrices[0].Store.Currency);
+        Assert.Equal(4.99f, watermelon.StorePrices[1].Price);
+        Assert.Equal("Store 7", watermelon.StorePrices[1].Store.Name);
+
+        var kiwi = fruits.First(f => f.Name == "Kiwi");
+        Assert.Equal("Small fuzzy green fruit", kiwi.Description);
+        Assert.Equal(1.99f, kiwi.StorePrices![0].Price);
+        Assert.Equal("Store 6", kiwi.StorePrices[0].Store.Name);
+    }
+
+    [Fact]
+    public async Task GetFruitFound()
+    {
+        var response = await _client.GetAsync("/fruits/Apple", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var fruit = await response.Content.ReadFromJsonAsync<FruitDto>(TestContext.Current.CancellationToken);
+        Assert.NotNull(fruit);
+        Assert.True(fruit.Id >= 1);
+        Assert.Equal("Apple",        fruit.Name);
+        Assert.Equal("Hearty fruit", fruit.Description);
+        Assert.Equal(1.29f,     fruit.StorePrices![0].Price);
+        Assert.Equal("Store 1",     fruit.StorePrices[0].Store.Name);
+        Assert.Equal("123 Main St", fruit.StorePrices[0].Store.Address!.Address);
+        Assert.Equal("Anytown",     fruit.StorePrices[0].Store.Address!.City);
+        Assert.Equal("USA",         fruit.StorePrices[0].Store.Address!.Country);
+        Assert.Equal("USD",         fruit.StorePrices[0].Store.Currency);
+        Assert.Equal(2.49f,   fruit.StorePrices[1].Price);
+        Assert.Equal("Store 2",    fruit.StorePrices[1].Store.Name);
+        Assert.Equal("456 Main St", fruit.StorePrices[1].Store.Address!.Address);
+        Assert.Equal("Paris",      fruit.StorePrices[1].Store.Address!.City);
+        Assert.Equal("France",     fruit.StorePrices[1].Store.Address!.Country);
+        Assert.Equal("EUR",        fruit.StorePrices[1].Store.Currency);
+    }
+
+    [Fact]
+    public async Task GetFruitNotFound()
+    {
+        var response = await _client.GetAsync("/fruits/XXXX", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddFruit()
+    {
+        // Capture the count before adding so the test is order-independent.
+        // This mirrors the Quarkus @QuarkusIntegrationTest addFruit() behaviour
+        // but without requiring this test to run after the read-only tests.
+        var countBefore = (await (await _client.GetAsync("/fruits", TestContext.Current.CancellationToken))
+            .Content.ReadFromJsonAsync<List<FruitDto>>(TestContext.Current.CancellationToken))!.Count;
+
+        // Use a unique name so the test is idempotent across repeated runs
+        var uniqueName = $"TestLemon_{Guid.NewGuid():N}";
+        var postResponse = await _client.PostAsJsonAsync("/fruits", new { name = uniqueName, description = "Acidic fruit" }, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, postResponse.StatusCode);
+
+        var dto = await postResponse.Content.ReadFromJsonAsync<FruitDto>(TestContext.Current.CancellationToken);
+        Assert.NotNull(dto);
+        Assert.True(dto.Id >= 1);
+        Assert.Equal(uniqueName,    dto.Name);
+        Assert.Equal("Acidic fruit", dto.Description);
+
+        var countAfter = (await (await _client.GetAsync("/fruits", TestContext.Current.CancellationToken))
+            .Content.ReadFromJsonAsync<List<FruitDto>>(TestContext.Current.CancellationToken))!.Count;
+        Assert.Equal(countBefore + 1, countAfter);
+    }
+}

--- a/dotnet10/Dotnet10.Tests/Infrastructure/PriorityOrderer.cs
+++ b/dotnet10/Dotnet10.Tests/Infrastructure/PriorityOrderer.cs
@@ -1,0 +1,4 @@
+// Ordering infrastructure removed.
+// FruitControllerEndToEndTest tests are fully independent and require no ordering.
+// See FruitControllerEndToEndTest.AddFruit for details.
+namespace Dotnet10.Tests.Infrastructure;

--- a/dotnet10/Dotnet10.Tests/Service/FruitServiceTests.cs
+++ b/dotnet10/Dotnet10.Tests/Service/FruitServiceTests.cs
@@ -1,0 +1,156 @@
+using Dotnet10.Domain;
+using Dotnet10.Dto;
+using Dotnet10.Repository;
+using Dotnet10.Service;
+using Xunit;
+
+namespace Dotnet10.Tests.Service;
+
+/// <summary>
+/// Unit tests for FruitService with a hand-written IFruitRepository fake.
+///
+/// Equivalent to @QuarkusTest FruitControllerTests in the Quarkus project.
+/// The Quarkus tests exercise the HTTP layer via rest-assured, but the intent
+/// is to verify that the business logic correctly maps domain objects to DTOs,
+/// applies the right repository calls, and handles missing results. Testing
+/// FruitService directly achieves the same coverage without any HTTP or framework
+/// infrastructure, and without a dependency on Microsoft.AspNetCore.Mvc.Testing.
+/// </summary>
+public class FruitServiceTests
+{
+    // ── fake ──────────────────────────────────────────────────────────────────
+
+    private sealed class FakeFruitRepository : IFruitRepository
+    {
+        public List<Fruit>? ListAllResult    { get; set; }
+        public Fruit?       FindByNameResult { get; set; }
+
+        public int     ListAllCalled    { get; private set; }
+        public int     FindByNameCalled { get; private set; }
+        public int     PersistCalled    { get; private set; }
+        public string? FindByNameArg    { get; private set; }
+        public Fruit?  PersistArg       { get; private set; }
+
+        public Task<List<Fruit>> ListAllAsync()
+        {
+            ListAllCalled++;
+            return Task.FromResult(ListAllResult
+                ?? throw new InvalidOperationException("ListAllResult not configured"));
+        }
+
+        public Task<Fruit?> FindByNameAsync(string name)
+        {
+            FindByNameCalled++;
+            FindByNameArg = name;
+            return Task.FromResult(FindByNameResult);
+        }
+
+        public Task PersistAsync(Fruit fruit)
+        {
+            PersistCalled++;
+            PersistArg = fruit;
+            return Task.CompletedTask;
+        }
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private static Fruit CreateFruit()
+    {
+        var store = new Store(1L, "Some Store", new Address("123 Some St", "Some City", "USA"), "USD");
+        var fruit = new Fruit(1L, "Apple", "Hearty Fruit");
+        fruit.StorePrices = [new StoreFruitPrice(store, fruit, 1.29m)];
+        return fruit;
+    }
+
+    // ── tests ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetAll()
+    {
+        var fruit = CreateFruit();
+        var store = fruit.StorePrices.First().Store;
+        var fake  = new FakeFruitRepository { ListAllResult = [fruit] };
+
+        var dtos = await new FruitService(fake).GetAllFruitsAsync();
+
+        Assert.Single(dtos);
+        var dto = dtos[0];
+        Assert.Equal(1L,            dto.Id);
+        Assert.Equal("Apple",       dto.Name);
+        Assert.Equal("Hearty Fruit", dto.Description);
+        Assert.NotNull(dto.StorePrices);
+        Assert.Single(dto.StorePrices);
+
+        var priceDto = dto.StorePrices[0];
+        Assert.Equal(1.29f,                    priceDto.Price);
+        Assert.Equal(store.Name,               priceDto.Store.Name);
+        Assert.Equal(store.Address.AddressLine, priceDto.Store.Address!.Address);
+        Assert.Equal(store.Address.City,       priceDto.Store.Address!.City);
+        Assert.Equal(store.Address.Country,    priceDto.Store.Address!.Country);
+        Assert.Equal(store.Currency,           priceDto.Store.Currency);
+
+        Assert.Equal(1, fake.ListAllCalled);
+        Assert.Equal(0, fake.FindByNameCalled);
+        Assert.Equal(0, fake.PersistCalled);
+    }
+
+    [Fact]
+    public async Task GetFruitByNameFound()
+    {
+        var fruit = CreateFruit();
+        var store = fruit.StorePrices.First().Store;
+        var fake  = new FakeFruitRepository { FindByNameResult = fruit };
+
+        var dto = await new FruitService(fake).GetFruitByNameAsync("Apple");
+
+        Assert.NotNull(dto);
+        Assert.Equal(1L,            dto.Id);
+        Assert.Equal("Apple",       dto.Name);
+        Assert.Equal("Hearty Fruit", dto.Description);
+
+        var priceDto = dto.StorePrices![0];
+        Assert.Equal(1.29f,                    priceDto.Price);
+        Assert.Equal(store.Name,               priceDto.Store.Name);
+        Assert.Equal(store.Address.AddressLine, priceDto.Store.Address!.Address);
+        Assert.Equal(store.Address.City,       priceDto.Store.Address!.City);
+        Assert.Equal(store.Address.Country,    priceDto.Store.Address!.Country);
+        Assert.Equal(store.Currency,           priceDto.Store.Currency);
+
+        Assert.Equal(1, fake.FindByNameCalled);
+        Assert.Equal("Apple", fake.FindByNameArg);
+        Assert.Equal(0, fake.ListAllCalled);
+        Assert.Equal(0, fake.PersistCalled);
+    }
+
+    [Fact]
+    public async Task GetFruitByNameNotFound()
+    {
+        var fake = new FakeFruitRepository { FindByNameResult = null };
+
+        var dto = await new FruitService(fake).GetFruitByNameAsync("Apple");
+
+        Assert.Null(dto);
+        Assert.Equal(1, fake.FindByNameCalled);
+        Assert.Equal("Apple", fake.FindByNameArg);
+        Assert.Equal(0, fake.ListAllCalled);
+        Assert.Equal(0, fake.PersistCalled);
+    }
+
+    [Fact]
+    public async Task AddFruit()
+    {
+        var fake  = new FakeFruitRepository();
+        var input = new FruitDto(null, "Grapefruit", "Summer fruit", null);
+
+        var result = await new FruitService(fake).CreateFruitAsync(input);
+
+        Assert.Equal("Grapefruit",  result.Name);
+        Assert.Equal("Summer fruit", result.Description);
+        Assert.Equal(1, fake.PersistCalled);
+        Assert.NotNull(fake.PersistArg);
+        Assert.Equal("Grapefruit", fake.PersistArg!.Name);
+        Assert.Equal(0, fake.ListAllCalled);
+        Assert.Equal(0, fake.FindByNameCalled);
+    }
+}

--- a/dotnet10/Dotnet10/Data/AppDbContext.cs
+++ b/dotnet10/Dotnet10/Data/AppDbContext.cs
@@ -1,0 +1,60 @@
+using Dotnet10.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dotnet10.Data;
+
+/// <summary>
+/// EF Core DbContext. Configures entity mappings that mirror the JPA annotations in the Quarkus project.
+/// </summary>
+public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+{
+    // Idiomatisches EF-Core-Muster: auto-property mit null!-Initializer.
+    // Set<T>() als expression-body-getter ist unüblich und ruft intern
+    // ohnehin dieselbe gecachte Methode auf – der Unterschied ist nur stilistisch.
+    public DbSet<Fruit> Fruits { get; set; } = null!;
+    public DbSet<Store> Stores { get; set; } = null!;
+    public DbSet<StoreFruitPrice> StoreFruitPrices { get; set; } = null!;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        // ── Fruit ──────────────────────────────────────────────────────────────
+        modelBuilder.Entity<Fruit>(e =>
+        {
+            e.ToTable("fruits");
+            e.HasKey(f => f.Id);
+            e.Property(f => f.Id).HasColumnName("id").UseHiLo("fruits_seq");
+            e.Property(f => f.Name).HasColumnName("name").IsRequired();
+            e.HasIndex(f => f.Name).IsUnique();
+            e.Property(f => f.Description).HasColumnName("description");
+        });
+
+        // ── Store ──────────────────────────────────────────────────────────────
+        modelBuilder.Entity<Store>(e =>
+        {
+            e.ToTable("stores");
+            e.HasKey(s => s.Id);
+            e.Property(s => s.Id).HasColumnName("id").UseHiLo("stores_seq");
+            e.Property(s => s.Name).HasColumnName("name").IsRequired();
+            e.HasIndex(s => s.Name).IsUnique();
+            e.Property(s => s.Currency).HasColumnName("currency").IsRequired();
+            e.OwnsOne(s => s.Address, a =>
+            {
+                a.Property(x => x.AddressLine).HasColumnName("address").IsRequired();
+                a.Property(x => x.City).HasColumnName("city").IsRequired();
+                a.Property(x => x.Country).HasColumnName("country").IsRequired();
+            });
+        });
+
+        // ── StoreFruitPrice ────────────────────────────────────────────────────
+        modelBuilder.Entity<StoreFruitPrice>(e =>
+        {
+            e.ToTable("store_fruit_prices");
+            e.HasKey(sp => new { sp.StoreId, sp.FruitId });
+            e.Property(sp => sp.StoreId).HasColumnName("store_id");
+            e.Property(sp => sp.FruitId).HasColumnName("fruit_id");
+            e.Property(sp => sp.Price).HasColumnName("price").HasPrecision(12, 2).IsRequired();
+            e.HasOne(sp => sp.Store).WithMany().HasForeignKey(sp => sp.StoreId).IsRequired();
+            e.HasOne(sp => sp.Fruit).WithMany(f => f.StorePrices).HasForeignKey(sp => sp.FruitId).IsRequired();
+        });
+    }
+}

--- a/dotnet10/Dotnet10/Domain/Address.cs
+++ b/dotnet10/Dotnet10/Domain/Address.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations;
+
+namespace Dotnet10.Domain;
+
+/// <summary>
+/// Embeddable address value object. Equivalent to @Embeddable Address in the Quarkus project.
+/// </summary>
+[Owned]
+public record Address(
+    [property: Required(ErrorMessage = "Address is mandatory")]
+    string AddressLine,
+
+    [property: Required(ErrorMessage = "City is mandatory")]
+    string City,
+
+    [property: Required(ErrorMessage = "Country is mandatory")]
+    string Country
+);

--- a/dotnet10/Dotnet10/Domain/Fruit.cs
+++ b/dotnet10/Dotnet10/Domain/Fruit.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Dotnet10.Domain;
+
+/// <summary>Fruit entity. Equivalent to @Entity Fruit in the Quarkus project.</summary>
+public class Fruit
+{
+    public long Id { get; set; }
+
+    [Required(ErrorMessage = "Name is mandatory")]
+    public string Name { get; set; } = null!;
+
+    public string? Description { get; set; }
+
+    public IList<StoreFruitPrice> StorePrices { get; set; } = [];
+
+    public Fruit() { }
+
+    public Fruit(long id, string name, string? description)
+    {
+        Id = id;
+        Name = name;
+        Description = description;
+    }
+}

--- a/dotnet10/Dotnet10/Domain/Store.cs
+++ b/dotnet10/Dotnet10/Domain/Store.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Dotnet10.Domain;
+
+/// <summary>Store entity. Equivalent to @Entity @Cacheable Store in the Quarkus project.</summary>
+public class Store
+{
+    public long Id { get; set; }
+
+    [Required(ErrorMessage = "Name is mandatory")]
+    public string Name { get; set; } = null!;
+
+    [Required(ErrorMessage = "Currency is mandatory")]
+    public string Currency { get; set; } = null!;
+
+    public Address Address { get; set; } = null!;
+
+    public Store() { }
+
+    public Store(long id, string name, Address address, string currency)
+    {
+        Id = id;
+        Name = name;
+        Address = address;
+        Currency = currency;
+    }
+}

--- a/dotnet10/Dotnet10/Domain/StoreFruitPrice.cs
+++ b/dotnet10/Dotnet10/Domain/StoreFruitPrice.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Dotnet10.Domain;
+
+/// <summary>
+/// Join entity with composite PK (StoreId, FruitId) and a price.
+/// Equivalent to @Entity StoreFruitPrice with @EmbeddedId in the Quarkus project.
+/// </summary>
+public class StoreFruitPrice
+{
+    public long StoreId { get; set; }
+    public long FruitId { get; set; }
+    public Store Store { get; set; } = null!;
+    public Fruit Fruit { get; set; } = null!;
+
+    [Required]
+    [Range(0, double.MaxValue, ErrorMessage = "Price must be >= 0")]
+    public decimal Price { get; set; }
+
+    public StoreFruitPrice() { }
+
+    public StoreFruitPrice(Store store, Fruit fruit, decimal price)
+    {
+        Store = store;
+        Fruit = fruit;
+        StoreId = store.Id;
+        FruitId = fruit.Id;
+        Price = price;
+    }
+}

--- a/dotnet10/Dotnet10/Dotnet10.csproj
+++ b/dotnet10/Dotnet10/Dotnet10.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>dotnet10</AssemblyName>
+    <RootNamespace>Dotnet10</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore"        Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.5" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting"          Version="1.11.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore"  Version="1.11.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime"     Version="1.11.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.0" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet10/Dotnet10/Dto/AddressDto.cs
+++ b/dotnet10/Dotnet10/Dto/AddressDto.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Dotnet10.Dto;
+
+/// <summary>
+/// DTO for Address. Equivalent to AddressDTO record in the Quarkus project.
+/// The <see cref="Address"/> property serialises to JSON key "address" (camelCase),
+/// matching the Quarkus response shape expected by tests.
+/// Validation is enforced by ASP.NET Core model validation (equivalent to Jakarta Bean Validation).
+/// </summary>
+public record AddressDto(
+    [property: Required(ErrorMessage = "Address is mandatory")]
+    string Address,
+
+    [property: Required(ErrorMessage = "City is mandatory")]
+    string City,
+
+    [property: Required(ErrorMessage = "Country is mandatory")]
+    string Country
+);

--- a/dotnet10/Dotnet10/Dto/FruitDto.cs
+++ b/dotnet10/Dotnet10/Dto/FruitDto.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Dotnet10.Dto;
+
+/// <summary>DTO for Fruit. Equivalent to FruitDTO record in the Quarkus project.</summary>
+public record FruitDto(
+    long? Id,
+
+    [property: Required(ErrorMessage = "Name is mandatory")]
+    string Name,
+
+    string? Description,
+
+    IReadOnlyList<StoreFruitPriceDto>? StorePrices = null)
+{
+    // Guarantee a non-null list for StorePrices – mirrors the null-coercion in the
+    // Java compact constructor. C# positional records allow overriding a positional
+    // property in the record body; the init accessor runs after the primary constructor.
+    public IReadOnlyList<StoreFruitPriceDto> StorePrices { get; init; } = StorePrices ?? [];
+}

--- a/dotnet10/Dotnet10/Dto/StoreDto.cs
+++ b/dotnet10/Dotnet10/Dto/StoreDto.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Dotnet10.Dto;
+
+/// <summary>DTO for Store. Equivalent to StoreDTO record in the Quarkus project.</summary>
+public record StoreDto(
+    long? Id,
+
+    [property: Required(ErrorMessage = "Name is mandatory")]
+    string Name,
+
+    [property: Required(ErrorMessage = "Currency is mandatory")]
+    string Currency,
+
+    AddressDto? Address
+);

--- a/dotnet10/Dotnet10/Dto/StoreFruitPriceDto.cs
+++ b/dotnet10/Dotnet10/Dto/StoreFruitPriceDto.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Dotnet10.Dto;
+
+/// <summary>DTO for a store-specific fruit price. Equivalent to StoreFruitPriceDTO record in the Quarkus project.</summary>
+public record StoreFruitPriceDto(
+    StoreDto Store,
+
+    [property: Range(0, float.MaxValue, ErrorMessage = "Price must be >= 0")]
+    float Price
+);

--- a/dotnet10/Dotnet10/FruitJsonContext.cs
+++ b/dotnet10/Dotnet10/FruitJsonContext.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+using Dotnet10.Dto;
+
+namespace Dotnet10;
+
+/// <summary>
+/// Source-generated JSON serializer context for all DTO types.
+///
+/// /// Equivalent to:
+///   quarkus.rest.jackson.optimization.enable-reflection-free-serializers: true
+/// </summary>
+[JsonSerializable(typeof(FruitDto))]
+[JsonSerializable(typeof(List<FruitDto>))]
+[JsonSerializable(typeof(StoreFruitPriceDto))]
+[JsonSerializable(typeof(List<StoreFruitPriceDto>))]
+[JsonSerializable(typeof(StoreDto))]
+[JsonSerializable(typeof(AddressDto))]
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    GenerationMode = JsonSourceGenerationMode.Default)]
+public partial class FruitJsonContext : JsonSerializerContext;

--- a/dotnet10/Dotnet10/Mapping/AddressMapper.cs
+++ b/dotnet10/Dotnet10/Mapping/AddressMapper.cs
@@ -1,0 +1,14 @@
+using Dotnet10.Domain;
+using Dotnet10.Dto;
+
+namespace Dotnet10.Mapping;
+
+/// <summary>Static mapper for Address ↔ AddressDto. Equivalent to AddressMapper in the Quarkus project.</summary>
+public static class AddressMapper
+{
+    public static AddressDto? Map(Address? address) =>
+        address is null ? null : new AddressDto(address.AddressLine, address.City, address.Country);
+
+    public static Address? Map(AddressDto? dto) =>
+        dto is null ? null : new Address(dto.Address, dto.City, dto.Country);
+}

--- a/dotnet10/Dotnet10/Mapping/FruitMapper.cs
+++ b/dotnet10/Dotnet10/Mapping/FruitMapper.cs
@@ -1,0 +1,29 @@
+using Dotnet10.Domain;
+using Dotnet10.Dto;
+
+namespace Dotnet10.Mapping;
+
+/// <summary>Static mapper for Fruit ↔ FruitDto. Equivalent to FruitMapper in the Quarkus project.</summary>
+public static class FruitMapper
+{
+    public static FruitDto? Map(Fruit? fruit)
+    {
+        if (fruit is null)
+            return null;
+
+        var storePrices = fruit.StorePrices
+            .Select(StoreFruitPriceMapper.Map)
+            .OfType<StoreFruitPriceDto>()
+            .ToList();
+
+        return new FruitDto(fruit.Id, fruit.Name, fruit.Description, storePrices);
+    }
+
+    public static Fruit? Map(FruitDto? dto)
+    {
+        if (dto is null)
+            return null;
+
+        return new Fruit { Name = dto.Name, Description = dto.Description };
+    }
+}

--- a/dotnet10/Dotnet10/Mapping/StoreFruitPriceMapper.cs
+++ b/dotnet10/Dotnet10/Mapping/StoreFruitPriceMapper.cs
@@ -1,0 +1,18 @@
+using Dotnet10.Domain;
+using Dotnet10.Dto;
+
+namespace Dotnet10.Mapping;
+
+/// <summary>
+/// Static mapper for StoreFruitPrice → StoreFruitPriceDto.
+/// Equivalent to StoreFruitPriceMapper in the Quarkus project.
+/// </summary>
+public static class StoreFruitPriceMapper
+{
+    public static StoreFruitPriceDto? Map(StoreFruitPrice? storeFruitPrice) =>
+        storeFruitPrice is null
+            ? null
+            : new StoreFruitPriceDto(
+                StoreMapper.Map(storeFruitPrice.Store)!,
+                (float)storeFruitPrice.Price);
+}

--- a/dotnet10/Dotnet10/Mapping/StoreMapper.cs
+++ b/dotnet10/Dotnet10/Mapping/StoreMapper.cs
@@ -1,0 +1,18 @@
+using Dotnet10.Domain;
+using Dotnet10.Dto;
+
+namespace Dotnet10.Mapping;
+
+/// <summary>Static mapper for Store ↔ StoreDto. Equivalent to StoreMapper in the Quarkus project.</summary>
+public static class StoreMapper
+{
+    public static StoreDto? Map(Store? store) =>
+        store is null
+            ? null
+            : new StoreDto(store.Id, store.Name, store.Currency, AddressMapper.Map(store.Address));
+
+    public static Store? Map(StoreDto? dto) =>
+        dto is null
+            ? null
+            : new Store(0, dto.Name, AddressMapper.Map(dto.Address)!, dto.Currency);
+}

--- a/dotnet10/Dotnet10/Program.cs
+++ b/dotnet10/Dotnet10/Program.cs
@@ -1,0 +1,87 @@
+using Dotnet10;
+using Dotnet10.Data;
+using Dotnet10.Dto;
+using Dotnet10.Repository;
+using Dotnet10.Service;
+using Microsoft.EntityFrameworkCore;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+var startTime = DateTime.UtcNow;
+
+var builder = WebApplication.CreateSlimBuilder(args);
+
+builder.Services.ConfigureHttpJsonOptions(options =>
+    options.SerializerOptions.TypeInfoResolverChain.Insert(0, FruitJsonContext.Default));
+
+// ── Database ──────────────────────────────────────────────────────────────────
+// Equivalent to quarkus-jdbc-postgresql + quarkus-hibernate-orm-panache.
+// Read the connection string from configuration when available (development),
+// fall back to the hardcoded default so the published binary works without
+// appsettings.json being present in the working directory.
+var connectionString =
+    builder.Configuration.GetConnectionString("DefaultConnection")
+    ?? "Host=localhost;Port=5432;Database=fruits;Username=fruits;Password=fruits";
+
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseNpgsql(connectionString));
+
+// ── Application Services ──────────────────────────────────────────────────────
+// Equivalent to @ApplicationScoped CDI beans in Quarkus.
+builder.Services.AddScoped<IFruitRepository, FruitRepository>();
+builder.Services.AddScoped<FruitService>();
+
+// ── Health checks ─────────────────────────────────────────────────────────────
+// Equivalent to quarkus-smallrye-health.
+builder.Services.AddHealthChecks()
+    .AddDbContextCheck<AppDbContext>();
+
+// ── OpenTelemetry ─────────────────────────────────────────────────────────────
+// Mirrors Quarkus: traces (10% sampling) + metrics via OTLP.
+// Endpoint defaults to http://localhost:4317; override via OTEL_EXPORTER_OTLP_ENDPOINT.
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(r => r.AddService("dotnet10"))
+    .WithTracing(tracing => tracing
+        .SetSampler(new TraceIdRatioBasedSampler(0.1))
+        .AddAspNetCoreInstrumentation()
+        .AddOtlpExporter())
+    .WithMetrics(metrics => metrics
+        .AddMeter("Microsoft.AspNetCore.Hosting")
+        .AddMeter("Microsoft.AspNetCore.Server.Kestrel")
+        .AddRuntimeInstrumentation()
+        .AddOtlpExporter());
+
+// Bind to port 8080 to match the Quarkus default.
+// Set in code so it applies to the published binary even without appsettings.json.
+builder.WebHost.UseUrls("http://0.0.0.0:8080");
+
+var app = builder.Build();
+
+// ── Fruit endpoints ───────────────────────────────────────────────────────────
+// Minimal API. Equivalent to @Path("/fruits") FruitController in the Quarkus project.
+var fruits = app.MapGroup("/fruits");
+
+fruits.MapGet("/", async (FruitService svc) =>
+    Results.Ok(await svc.GetAllFruitsAsync()));
+
+fruits.MapGet("/{name}", async (string name, FruitService svc) =>
+{
+    var fruit = await svc.GetFruitByNameAsync(name);
+    return fruit is null ? Results.NotFound() : Results.Ok(fruit);
+});
+
+fruits.MapPost("/", async (FruitDto dto, FruitService svc) =>
+    Results.Ok(await svc.CreateFruitAsync(dto)));
+
+// ── Health endpoints ──────────────────────────────────────────────────────────
+app.MapHealthChecks("/health/live");
+app.MapHealthChecks("/health/ready");
+
+// Emit a startup log that matches the perf-lab logFileStartedRegex ".*dotnet10.+started in.*"
+// so the qDup watch-log script knows when the app is ready to accept traffic.
+app.Lifetime.ApplicationStarted.Register(() =>
+    app.Logger.LogInformation("dotnet10 started in {Elapsed:F3}s",
+        (DateTime.UtcNow - startTime).TotalSeconds));
+
+app.Run();

--- a/dotnet10/Dotnet10/Repository/FruitRepository.cs
+++ b/dotnet10/Dotnet10/Repository/FruitRepository.cs
@@ -1,0 +1,32 @@
+using Dotnet10.Data;
+using Dotnet10.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dotnet10.Repository;
+
+/// <summary>
+/// EF Core implementation of IFruitRepository.
+/// Equivalent to FruitRepository extends PanacheRepository&lt;Fruit&gt; in the Quarkus project.
+/// Eager loading of StorePrices and their Stores mirrors Hibernate FetchType.EAGER / FetchMode.SELECT.
+/// </summary>
+public class FruitRepository(AppDbContext context) : IFruitRepository
+{
+    public async Task<List<Fruit>> ListAllAsync() =>
+        await context.Fruits
+            .Include(f => f.StorePrices)
+            .ThenInclude(sp => sp.Store)
+            .OrderBy(f => f.Id)
+            .ToListAsync();
+
+    public async Task<Fruit?> FindByNameAsync(string name) =>
+        await context.Fruits
+            .Include(f => f.StorePrices)
+            .ThenInclude(sp => sp.Store)
+            .FirstOrDefaultAsync(f => f.Name == name);
+
+    public async Task PersistAsync(Fruit fruit)
+    {
+        context.Fruits.Add(fruit);
+        await context.SaveChangesAsync();
+    }
+}

--- a/dotnet10/Dotnet10/Repository/IFruitRepository.cs
+++ b/dotnet10/Dotnet10/Repository/IFruitRepository.cs
@@ -1,0 +1,14 @@
+using Dotnet10.Domain;
+
+namespace Dotnet10.Repository;
+
+/// <summary>
+/// Repository contract for Fruit. Extracted as an interface to allow faking in unit tests.
+/// Equivalent to PanacheRepository&lt;Fruit&gt; in the Quarkus project.
+/// </summary>
+public interface IFruitRepository
+{
+    Task<List<Fruit>> ListAllAsync();
+    Task<Fruit?> FindByNameAsync(string name);
+    Task PersistAsync(Fruit fruit);
+}

--- a/dotnet10/Dotnet10/Service/FruitService.cs
+++ b/dotnet10/Dotnet10/Service/FruitService.cs
@@ -1,0 +1,37 @@
+using Dotnet10.Dto;
+using Dotnet10.Mapping;
+using Dotnet10.Repository;
+
+namespace Dotnet10.Service;
+
+/// <summary>
+/// Application service for Fruit operations.
+/// Equivalent to @ApplicationScoped FruitService in the Quarkus project.
+/// Transaction management is handled by the repository (SaveChangesAsync).
+/// </summary>
+public class FruitService(IFruitRepository fruitRepository)
+{
+    /// <summary>Returns all fruits as DTOs. Equivalent to getAllFruits() @Transactional(SUPPORTS).</summary>
+    public async Task<List<FruitDto>> GetAllFruitsAsync() =>
+        [.. (await fruitRepository.ListAllAsync())
+            .Select(FruitMapper.Map)
+            .OfType<FruitDto>()];
+
+    /// <summary>
+    /// Finds a fruit by name. Equivalent to getFruitByName() @Transactional(SUPPORTS).
+    /// Returns null instead of Optional.empty() – idiomatic C# nullable reference type.
+    /// </summary>
+    public async Task<FruitDto?> GetFruitByNameAsync(string name)
+    {
+        var fruit = await fruitRepository.FindByNameAsync(name);
+        return fruit is null ? null : FruitMapper.Map(fruit);
+    }
+
+    /// <summary>Creates and persists a new fruit. Equivalent to createFruit() @Transactional.</summary>
+    public async Task<FruitDto> CreateFruitAsync(FruitDto fruitDto)
+    {
+        var fruit = FruitMapper.Map(fruitDto)!;
+        await fruitRepository.PersistAsync(fruit);
+        return FruitMapper.Map(fruit)!;
+    }
+}

--- a/dotnet10/Dotnet10/appsettings.Development.json
+++ b/dotnet10/Dotnet10/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore.Database.Command": "Information"
+    }
+  }
+}

--- a/dotnet10/Dotnet10/appsettings.json
+++ b/dotnet10/Dotnet10/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Urls": "http://0.0.0.0:8080",
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=fruits;Username=fruits;Password=fruits"
+  }
+}

--- a/dotnet10/README.md
+++ b/dotnet10/README.md
@@ -1,0 +1,186 @@
+# dotnet10
+
+.NET 10 / ASP.NET Core counterpart of the `quarkus3` project, built for framework performance comparisons.
+
+## How to run `stress.sh`?
+
+1. Install .NET (see Prerequisites)
+2. Compile to managed mode with `dotnet publish Dotnet10 -c Release -o publish`
+   (see Managed mode)
+3. From the Git project root run `./scripts/stress.sh dotnet10/publish/dotnet10`
+
+## How to run `1strequest.sh`
+
+1. Install .NET (see Prerequisites)
+2. Compile to managed mode with `dotnet publish Dotnet10 -c Release -o publish`
+   (see Managed mode)
+3. From the Git project root run `./scripts/1strequest.sh "dotnet10/publish/dotnet10" 5`
+
+## Prerequisites
+
+### .NET 10 SDK
+
+#### Linux
+
+**Ubuntu / Debian**
+
+```bash
+sudo apt-get update && sudo apt-get install -y dotnet-sdk-10.0
+```
+
+If the package is not found, register the Microsoft package feed first:
+
+```bash
+wget https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb \
+     -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb && rm packages-microsoft-prod.deb
+sudo apt-get update && sudo apt-get install -y dotnet-sdk-10.0
+```
+
+**Fedora / RHEL / CentOS**
+
+```bash
+sudo dnf install dotnet-sdk-10.0
+```
+
+#### macOS
+
+```bash
+brew install dotnet@10
+```
+
+Or download the `.pkg` installer from <https://dotnet.microsoft.com/en-us/download/dotnet/10.0>.
+
+#### Windows
+
+```powershell
+winget install Microsoft.DotNet.SDK.10
+```
+
+Or download the `.exe` installer from <https://dotnet.microsoft.com/en-us/download/dotnet/10.0>.
+
+#### Verify
+
+```bash
+dotnet --version   # should print 10.x.x
+```
+
+## Database
+
+PostgreSQL on `localhost:5432`, database `fruits`, user `fruits`, password `fruits`.
+
+## Managed mode
+
+Compiles to platform-neutral IL that runs on the installed .NET runtime.
+Equivalent to `./mvnw clean package` + `java -jar target/quarkus-app/quarkus-run.jar` in the Quarkus project.
+
+```bash
+dotnet publish Dotnet10 -c Release -o publish
+./publish/dotnet10
+```
+
+The server listens on **http://localhost:8080**, matching the Quarkus default.
+
+## Native mode
+
+**Not supported.** EF Core's NativeAOT support is still experimental and not suited for
+production use. See the official Microsoft documentation for details:
+[NativeAOT Support and Precompiled Queries (Experimental) – EF Core](https://learn.microsoft.com/en-us/ef/core/performance/nativeaot-and-precompiled-queries)
+
+The managed-mode binary (`dotnet publish -c Release`) is the valid comparison point
+against the Quarkus JVM build.
+
+### Why Quarkus native image works
+
+The Quarkus team ships a complete GraalVM native-image configuration for Hibernate ORM
+and RESTEasy as part of the framework extensions. Query translation, model building, and
+reflection metadata are all handled at build time through Quarkus's own
+bytecode-transformation infrastructure. This is years of framework-level investment that
+has no equivalent in the .NET ecosystem yet.
+
+### What to expect in future versions
+
+EF Core's roadmap includes full NativeAOT support. The pieces being developed are:
+
+- **Compiled models** (`dotnet ef dbcontext optimize`) — already working in EF Core 8+.
+- **Precompiled queries** via C# interceptors — introduced as experimental in EF Core 9,
+  currently limited to simple queries without navigation property loading.
+- **Full `Include` support** in the precompiler — planned for a future EF Core release
+  once the interceptor infrastructure matures.
+
+When precompiled queries fully support navigation properties and eager loading, native
+compilation of this project should become possible without any code changes beyond
+running `dotnet ef dbcontext optimize` and `dotnet publish -p:PublishAot=true`.
+
+## Development
+
+```bash
+dotnet run --project Dotnet10
+```
+
+## Test
+
+The test suite has three levels, matching the Quarkus test structure:
+
+### Unit tests (`Service/FruitServiceTests`)
+
+Tests `FruitService` directly with a hand-written fake repository. No database or running
+application required. Equivalent to `@QuarkusTest FruitControllerTests` in the Quarkus project.
+
+```bash
+dotnet test --filter "FullyQualifiedName~Service"
+```
+
+### End-to-end tests (`E2e/FruitControllerEndToEndTest`)
+
+Tests the full HTTP API of the running application. Equivalent to
+`@QuarkusIntegrationTest FruitControllerIT` in the Quarkus project. Requires the
+application to be running (`dotnet run --project Dotnet10`) and the database
+seeded from `import.sql` before the tests are started. Seeding the database is
+best done using `../script/infra.sh -s`.
+
+```bash
+dotnet test --filter "FullyQualifiedName~E2e"
+```
+
+### Run all tests
+
+```bash
+dotnet test
+```
+
+## API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/fruits` | All fruits with store prices |
+| GET | `/fruits/{name}` | Single fruit or 404 |
+| POST | `/fruits` | Create a new fruit |
+| GET | `/health/live` | Liveness probe |
+| GET | `/health/ready` | Readiness probe (includes DB check) |
+| GET | `/metrics` | Prometheus metrics |
+
+## Architecture comparison with quarkus3
+
+| Concern | Quarkus 3 | dotnet10 |
+|---------|-----------|----------|
+| HTTP layer | `quarkus-rest-jackson` / JAX-RS `@Path` | ASP.NET Core Minimal API (`MapGet` / `MapPost`) |
+| ORM | Hibernate ORM + Panache | EF Core 10 + Npgsql |
+| Embedded value object | `@Embeddable` / `@Embedded` | `[Owned]` (EF Core owned type) |
+| Composite PK | `@EmbeddedId` / `@MapsId` | `HasKey(e => new { e.StoreId, e.FruitId })` |
+| Eager fetch | `FetchType.EAGER` + `@Fetch(SELECT)` | `.Include().ThenInclude()` in repository |
+| Natural ID / unique key | `@NaturalId` | `HasIndex(x => x.Name).IsUnique()` |
+| DI scope | `@ApplicationScoped` (CDI) | `AddScoped()` (ASP.NET Core DI) |
+| Bean Validation | `jakarta.validation` annotations | DataAnnotations + `[ApiController]` auto-400 |
+| Health checks | `quarkus-smallrye-health` | `AddHealthChecks()` + `AddDbContextCheck<T>()` |
+| Metrics | `quarkus-micrometer-registry-prometheus` | `prometheus-net.AspNetCore` |
+| JSON null handling | `serialization-inclusion: non-empty` | `JsonIgnoreCondition.WhenWritingNull` |
+| Reflection-free JSON | `enable-reflection-free-serializers: true` | Source-generated `System.Text.Json` (`JsonSerializerContext`) |
+| AOT build flag | `./mvnw clean package -Pnative` | Not supported – [EF Core NativeAOT is experimental](https://learn.microsoft.com/en-us/ef/core/performance/nativeaot-and-precompiled-queries) |
+| AOT output | `target/app-runner` (GraalVM native image) | Not available |
+| Unit test framework | JUnit 5 + `@QuarkusTest` | xUnit |
+| Unit test mock | `@InjectMock` (Mockito) | Hand-written `FakeFruitRepository` |
+| Unit test target | `FruitController` via HTTP | `FruitService` directly |
+| Repository tests | `@TestTransaction` rollback | Covered by E2E tests (no separate process needed) |
+| E2E tests | `@QuarkusIntegrationTest` (separate process) | `HttpClient` against running app |
+| Test ordering | `@TestMethodOrder` + `@Order` | `PriorityOrderer` + `[TestPriority]` |

--- a/dotnet10/dotnet10.sln
+++ b/dotnet10/dotnet10.sln
@@ -1,0 +1,22 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dotnet10", "Dotnet10\Dotnet10.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dotnet10.Tests", "Dotnet10.Tests\Dotnet10.Tests.csproj", "{B2C3D4E5-F6A7-8901-BCDE-F12345678901}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/dotnet10/global.json
+++ b/dotnet10/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.0",
+    "rollForward": "minor"
+  }
+}

--- a/scripts/1strequest.sh
+++ b/scripts/1strequest.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
+
 # 1st argument is the command to execute
 # 2nd argument is the number of iterations. If not specified defaults to 1
-
+# --no-purge: skip OS page cache drop (useful for local dev without sudo)
+#
 # Example usage
 # 1) Run the Spring app 10 times
 # $ ./1strequest.sh "java -XX:ActiveProcessorCount=8 -Xms512m -Xmx512m -jar ../springboot3/target/springboot3.jar" 10
@@ -12,6 +14,9 @@
 #
 # 3) Run the Quarkus with spring compatibility app 10 times
 # $ ./1strequest.sh "java -XX:ActiveProcessorCount=8 -Xms512m -Xmx512m -jar ../quarkus3-spring-compatibility/target/quarkus-app/quarkus-run.jar" 10
+#
+# 4) Run the dotnet app 3 times without sudo (local dev)
+# $ ./1strequest.sh "dotnet10/publish/dotnet10" 3 --no-purge
 set -euo pipefail
 
 thisdir=`dirname "$0"`
@@ -20,6 +25,7 @@ COMMAND=$1
 NUM_ITERATIONS=1
 TOTAL_RSS=0
 TOTAL_TTFR=0
+NO_PURGE=false
 
 function _date() {
     current=$(date +%s%N)
@@ -29,24 +35,44 @@ function _date() {
     echo "$current"
 }
 
-if [ "$#" -eq 2 ]; then
+if [ "$#" -ge 2 ]; then
   NUM_ITERATIONS=$2
+fi
+for arg in "$@"; do
+  if [ "$arg" = "--no-purge" ]; then NO_PURGE=true; fi
+done
+
+LC_NUMERIC=C
+if [[ "$1" != *.jar ]]; then
+  # .NET Environment variables to mimic Java -Xmx and -XX:ActiveProcessorCount:
+  # DOTNET_GCHeapHardLimit: Hard memory limit in hex (0x20000000 = 512MB)
+  # DOTNET_ProcessorCount: Limits the CPU cores the runtime perceives
+  # DOTNET_gcServer: Enables Server GC for high-throughput
+  export DOTNET_GCHeapHardLimit=0x20000000
+  export DOTNET_ProcessorCount=4
+  export DOTNET_gcServer=1
+
+  # Suppress logging
+  export Logging__LogLevel__Default=None
 fi
 
 for (( i=0; i<$NUM_ITERATIONS; i++))
 do
   # drop OS page cache entries, inode etc etc
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    sync && sudo purge
-  else
-    # Linux: drop pagecache, dentries and inodes
-    sync && sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'
+  if [ "$NO_PURGE" = false ]; then
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      sync && sudo purge
+    else
+      # Linux: drop pagecache, dentries and inodes
+      sync && sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'
+    fi
   fi
 
   # Start the infra
   ${thisdir}/infra.sh -s
 
   ts=$(_date)
+
   $COMMAND &
   CURRENT_PID=$!
 

--- a/scripts/perf-lab/helpers/dotnet.yml
+++ b/scripts/perf-lab/helpers/dotnet.yml
@@ -1,0 +1,8 @@
+name: Dotnet related scripts
+scripts:
+  # Generic check — satisfied by any installed .NET SDK version.
+  # When adding a new dotnet version (e.g., dotnet11) no change is needed here
+  # unless you want to pin to a specific major version.
+  ensure-dotnet:
+    - log: Showing Dotnet version
+    - sh: dotnet --version

--- a/scripts/perf-lab/helpers/requirements.yml
+++ b/scripts/perf-lab/helpers/requirements.yml
@@ -7,6 +7,7 @@ scripts:
     - script: ensure-gcc
     - script: ensure-jbang
     - script: ensure-jvm-opts
+    - script: ensure-dotnet
 
   ensure-jvm-opts:
     - read-state: config.profiler.name

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -587,6 +587,16 @@ scripts:
         - script: sync-drop-fs-cache
         - set-signal: LOAD_STEADY_STATE_START 1
         - set-signal: LOG_REGEX_REACHED 1
+        - script:
+            # Start watch-log BEFORE the app so tail -f sees output as new lines.
+            # If watch-log is started after the app, tail reads the already-written
+            # "started" message as existing file content and fires the signal before
+            # the app is truly serving traffic (or before wrk has started).
+            name: watch-log
+            async: true
+          with:
+            log_file: ${{LOG_FILE}}
+            log_regex: ${{APP_LOG_REGEX}}
         - read-state: ${{config.profiler.name}}
           then:
             - regex: "^syncjfr$"
@@ -627,12 +637,6 @@ scripts:
                     format: ${{config.profiler.name}}
                     events: ${{config.profiler.events}}
                     delay: 10s
-        - script:
-            name: watch-log
-            async: true
-          with:
-            log_file: ${{LOG_FILE}}
-            log_regex: ${{APP_LOG_REGEX}}
         - wait-for: LOG_REGEX_REACHED
         - sh: ${{RUN.WRK_BIN}} -t 2 -c 100 -d 2m --timeout 2m ${{TARGET_URL}} 2>&1 >${{REPO_DIR}}/logs/wrk-warmup-${{RUNTIMECMD.name}}-${{ITERATION}}.log
         - regex: unable to connect
@@ -725,7 +729,6 @@ scripts:
         - regex: "${{log_regex}}"
           then:
             - ctrlC
-            - sleep: 1s # give the main thread time to register wait-for before the signal fires
             - signal: LOG_REGEX_REACHED
       timer:
         1m:

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -59,7 +59,7 @@ states:
   PROFILER_JVM_ARGS:
   BASE_JAVA_CMD: ${{APP_CMD_PREFIX}} java ${{config.jvm.memory}} ${{config.jvm.args}} ${{PROFILER_JVM_ARGS}}
   TESTS : [measure-time-to-first-request, measure-rss, run-load-test]
-  RUNTIMES: [quarkus3-jvm, quarkus3-virtual, quarkus3-native, spring3-jvm, spring3-virtual, spring3-native, spring4-jvm, spring4-virtual, spring4-native]
+  RUNTIMES: [quarkus3-jvm, quarkus3-virtual, quarkus3-native, spring3-jvm, spring3-virtual, spring3-native, spring4-jvm, spring4-virtual, spring4-native, dotnet10]
   TARGET_URL: http://localhost:8080/fruits
   QUARKUS-PLATFORM-ARTIFACT-ID: quarkus-bom
   PROJ_REPO_NAME: spring-quarkus-perf-comparison
@@ -219,6 +219,13 @@ states:
       buildCmd: "${{APP_CMD_PREFIX}} ./mvnw clean -Pnative -DskipTests native:compile package ${{config.springboot4.native_build_options}}"
       runCmd: "${{APP_CMD_PREFIX}} ${{RUNTIME_BUILD_DIR}}/springboot4 ${{config.jvm.memory}}"
       logFileStartedRegex: ".*Started SpringBoot4Application in.+seconds.*"
+    - name: dotnet10
+      type: dotnet
+      dir: ${{DOTNET10_DIR}}
+      updateScript: skip-version-update
+      buildCmd: "dotnet publish Dotnet10 -c Release -o publish"
+      runCmd: "env DOTNET_GCHeapHardLimit=${{config.dotnet.gcHeapHardLimit}} DOTNET_ProcessorCount=${{config.resources.app_cpus}} DOTNET_gcServer=1 ${{APP_CMD_PREFIX}} ./publish/dotnet10"
+      logFileStartedRegex: ".*dotnet10.+started in.*"
 
 scripts:
   update-state:
@@ -234,6 +241,7 @@ scripts:
     - set-state: RUN.QUARKUS3_VIRTUAL_DIR ${{PROJ_REPO_DIR}}/quarkus3-virtual
     - set-state: RUN.BUILDS_DIR ${{PROJ_REPO_DIR}}/builds
     - set-state: RUN.ASYNC_PROFILER_DIR ${{BASE_DIR}}/${{ASYNC_PROFILER}}
+    - set-state: RUN.DOTNET10_DIR ${{PROJ_REPO_DIR}}/dotnet10
 
   output-vars:
     - log: |
@@ -389,6 +397,9 @@ scripts:
 
   abort-script-not-found:
     - abort: script not found
+
+  skip-version-update:
+    - log: "Skipping version update (not applicable for ${{RUNTIMECMD.name}})"
 
   measure-build-times:
     - log: Build times

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -725,6 +725,7 @@ scripts:
         - regex: "${{log_regex}}"
           then:
             - ctrlC
+            - sleep: 1s # give the main thread time to register wait-for before the signal fires
             - signal: LOG_REGEX_REACHED
       timer:
         1m:

--- a/scripts/perf-lab/run-benchmarks.sh
+++ b/scripts/perf-lab/run-benchmarks.sh
@@ -76,8 +76,8 @@ help() {
   echo "  --repo-url <SCM_REPO_URL>                               The SCM repo url"
   echo "                                                              Default: '${SCM_REPO_URL}'"
   echo "  --runtimes <RUNTIMES>                                   The runtimes to test, separated by commas"
-  echo "                                                              Accepted values (1 or more of): quarkus3-jvm, quarkus3-leyden, quarkus3-virtual, quarkus3-virtual-leyden, quarkus3-native, spring3-jvm, spring3-leyden, spring3-virtual, spring3-virtual-leyden, spring3-jvm-aot, spring3-native, spring4-jvm, spring4-leyden, spring4-virtual, spring4-virtual-leyden, spring4-jvm-aot, spring4-native"
-  echo "                                                              Default: 'quarkus3-jvm,quarkus3-leyden,quarkus3-virtual,quarkus3-virtual-leyden,quarkus3-native,spring3-jvm,spring3-leyden,spring3-jvm-aot,spring3-virtual,spring3-virtual-leyden,spring3-native,spring4-jvm,spring4-leyden,spring4-virtual,spring4-virtual-leyden,spring4-jvm-aot,spring4-native'"
+  echo "                                                              Accepted values (1 or more of): quarkus3-jvm, quarkus3-leyden, quarkus3-virtual, quarkus3-virtual-leyden, quarkus3-native, spring3-jvm, spring3-leyden, spring3-virtual, spring3-virtual-leyden, spring3-jvm-aot, spring3-native, spring4-jvm, spring4-leyden, spring4-virtual, spring4-virtual-leyden, spring4-jvm-aot, spring4-native, dotnet10"
+  echo "                                                              Default: 'quarkus3-jvm,quarkus3-leyden,quarkus3-virtual,quarkus3-virtual-leyden,quarkus3-native,spring3-jvm,spring3-leyden,spring3-jvm-aot,spring3-virtual,spring3-virtual-leyden,spring3-native,spring4-jvm,spring4-leyden,spring4-virtual,spring4-virtual-leyden,spring4-jvm-aot,spring4-native,dotnet10'"
   echo "  --run-identifier <RUN_IDENTIFIER>                       An optional identifier for this run to be added to the run output"
   echo "  --scenario <SCENARIO>                                   The scenario to run"
   echo "                                                              Accepted values: tuned, ootb"
@@ -219,6 +219,29 @@ count_cpus() {
   echo "$count"
 }
 
+# Converts the -Xmx value from a JVM memory string (e.g. "-Xms512m -Xmx512m") to the
+# hex byte count required by DOTNET_GCHeapHardLimit (e.g. 0x20000000).
+# Falls back to 512 MiB if no -Xmx is found.
+xmx_to_dotnet_gc_limit() {
+  local jvm_mem="$1"
+  local xmx
+  xmx=$(echo "$jvm_mem" | grep -oE '\-Xmx[0-9]+[mMgGkK]?' | sed 's/-Xmx//')
+  if [[ -z "$xmx" ]]; then
+    printf '0x%X\n' $(( 512 * 1024 * 1024 ))
+    return
+  fi
+  local num unit bytes
+  num=$(echo "$xmx" | grep -oE '^[0-9]+')
+  unit=$(echo "$xmx" | grep -oE '[mMgGkK]$' || true)
+  case "${unit,,}" in
+    m) bytes=$(( num * 1024 * 1024 )) ;;
+    g) bytes=$(( num * 1024 * 1024 * 1024 )) ;;
+    k) bytes=$(( num * 1024 )) ;;
+    *) bytes=$num ;;
+  esac
+  printf '0x%X\n' "$bytes"
+}
+
 setup_jbang() {
   if command -v jbang &> /dev/null; then
     echo "Using installed jbang ($(jbang --version))"
@@ -285,6 +308,7 @@ ${JBANG_CMD} io.hyperfoil.tools:qDup:0.11.0 \
     -S config.springboot3.version=${SPRING_BOOT3_VERSION} \
     -S config.springboot4.version=${SPRING_BOOT4_VERSION} \
     -S config.jvm.memory="${JVM_MEMORY}" \
+    -S config.dotnet.gcHeapHardLimit="$(xmx_to_dotnet_gc_limit "${JVM_MEMORY}")" \
     -S config.quarkus.build_config_args="${QUARKUS_BUILD_CONFIG_ARGS}" \
     -S config.quarkus.version=${QUARKUS_VERSION} \
     -S config.springboot3.native_build_options="${NATIVE_SPRING3_BUILD_OPTIONS}" \
@@ -335,8 +359,8 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   PROFILER="none"
   QUARKUS_BUILD_CONFIG_ARGS=""
   QUARKUS_VERSION=""
-  ALLOWED_RUNTIMES=("quarkus3-jvm" "quarkus3-leyden" "quarkus3-virtual" "quarkus3-virtual-leyden" "quarkus3-native" "spring3-jvm" "spring3-leyden" "spring3-virtual" "spring3-virtual-leyden" "spring3-jvm-aot" "spring3-native" "spring4-jvm" "spring4-leyden" "spring4-virtual" "spring4-virtual-leyden" "spring4-jvm-aot" "spring4-native")
-  DEFAULT_RUNTIMES=("quarkus3-jvm" "quarkus3-leyden" "quarkus3-virtual" "quarkus3-virtual-leyden" "quarkus3-native" "spring3-jvm" "spring3-leyden" "spring3-virtual" "spring3-virtual-leyden" "spring3-native" "spring4-jvm" "spring4-leyden" "spring4-virtual" "spring4-virtual-leyden" "spring4-native")
+  ALLOWED_RUNTIMES=("quarkus3-jvm" "quarkus3-leyden" "quarkus3-virtual" "quarkus3-virtual-leyden" "quarkus3-native" "spring3-jvm" "spring3-leyden" "spring3-virtual" "spring3-virtual-leyden" "spring3-jvm-aot" "spring3-native" "spring4-jvm" "spring4-leyden" "spring4-virtual" "spring4-virtual-leyden" "spring4-jvm-aot" "spring4-native" "dotnet10")
+  DEFAULT_RUNTIMES=("quarkus3-jvm" "quarkus3-leyden" "quarkus3-virtual" "quarkus3-virtual-leyden" "quarkus3-native" "spring3-jvm" "spring3-leyden" "spring3-virtual" "spring3-virtual-leyden" "spring3-native" "spring4-jvm" "spring4-leyden" "spring4-virtual" "spring4-virtual-leyden" "spring4-native" "dotnet10")
   RUNTIMES=${DEFAULT_RUNTIMES[@]}
   SPRING_BOOT3_VERSION=""
   SPRING_BOOT4_VERSION=""

--- a/scripts/remote-setup.sh
+++ b/scripts/remote-setup.sh
@@ -69,7 +69,8 @@ ${BOLD}What this script does:${NC}
   3. Installs the public key on the remote host (passwordless SSH login)
   4. Configures passwordless sudo for the remote user
   5. Verifies the remote shell environment
-  6. Prints example run-benchmarks.sh commands
+  6. Ensures the C/C++ build toolchain is present (required for native image builds)
+  7. Prints example run-benchmarks.sh commands
 
 ${BOLD}After a successful run:${NC}
   cd scripts/perf-lab
@@ -243,7 +244,103 @@ setup_passwordless_sudo() {
   fi
 }
 
-# ─── 5. Remote environment verification ───────────────────────────────────────
+# ─── 5. C/C++ build toolchain ────────────────────────────────────────────────
+ensure_build_toolchain() {
+  step "C/C++ build toolchain"
+
+  # Check each required tool independently so we install anything that's missing
+  # even if some tools are already present.
+  local need_gcc=false need_zlib=false
+
+  if ssh_batch "command -v gcc" &>/dev/null; then
+    local gcc_ver
+    gcc_ver=$(ssh_batch "gcc --version 2>/dev/null | head -1")
+    ok "gcc: $gcc_ver"
+  else
+    warn "gcc not found"
+    need_gcc=true
+  fi
+
+  # Probe for zlib dev headers via the pkg-config or a direct header check.
+  if ssh_batch "pkg-config --exists zlib 2>/dev/null || test -f /usr/include/zlib.h" &>/dev/null; then
+    ok "zlib dev headers: present"
+  else
+    warn "zlib dev headers not found (GraalVM native-image linker requires -lz)"
+    need_zlib=true
+  fi
+
+  if ! $need_gcc && ! $need_zlib; then
+    return
+  fi
+
+  if $CHECK_ONLY; then
+    $need_gcc  && warn "Re-run without --check-only to install the C/C++ toolchain."
+    $need_zlib && warn "Re-run without --check-only to install zlib dev headers."
+    return
+  fi
+
+  info "Detecting Linux distribution …"
+
+  local distro_id distro_like
+  distro_id=$(ssh_batch ". /etc/os-release && echo \$ID" 2>/dev/null | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+  distro_like=$(ssh_batch ". /etc/os-release && echo \${ID_LIKE:-}" 2>/dev/null | tr '[:upper:]' '[:lower:]')
+
+  local pkg_cmd="" pre_cmd=""
+  case "$distro_id" in
+    ubuntu|debian|linuxmint|pop)
+      pre_cmd="apt-get update -y"
+      pkg_cmd="apt-get install -y build-essential zlib1g-dev" ;;
+    fedora)
+      pkg_cmd="dnf install -y gcc gcc-c++ make zlib-devel" ;;
+    rhel|centos|almalinux|rocky)
+      pkg_cmd="dnf groupinstall -y 'Development Tools' && sudo dnf install -y zlib-devel" ;;
+    opensuse*|sles)
+      pkg_cmd="zypper install -y gcc gcc-c++ make zlib-devel" ;;
+    arch|manjaro)
+      pkg_cmd="pacman -Sy --noconfirm base-devel" ;;
+    *)
+      if [[ "$distro_like" == *debian* || "$distro_like" == *ubuntu* ]]; then
+        pre_cmd="apt-get update -y"
+        pkg_cmd="apt-get install -y build-essential zlib1g-dev"
+      elif [[ "$distro_like" == *fedora* || "$distro_like" == *rhel* ]]; then
+        pkg_cmd="dnf install -y gcc gcc-c++ make zlib-devel"
+      else
+        warn "Unknown distribution '$distro_id' — cannot auto-install the build toolchain."
+        warn "Please install gcc and zlib dev headers manually (e.g. 'build-essential zlib1g-dev' on Debian/Ubuntu)."
+        return
+      fi ;;
+  esac
+
+  if [[ -n "$pre_cmd" ]]; then
+    info "Refreshing package lists: sudo $pre_cmd"
+    ssh_batch "sudo $pre_cmd" || warn "Package list update failed — will try installing anyway."
+  fi
+
+  info "Installing build toolchain on remote host: sudo $pkg_cmd"
+  ssh_batch "sudo $pkg_cmd" || die "Failed to install build toolchain. Install manually with: sudo $pkg_cmd"
+
+  # Verify both tools are now present
+  local post_failed=0
+  if ssh_batch "command -v gcc" &>/dev/null; then
+    local gcc_ver
+    gcc_ver=$(ssh_batch "gcc --version 2>/dev/null | head -1")
+    ok "gcc installed: $gcc_ver"
+  else
+    err "gcc still not found after installation."
+    (( post_failed++ )) || true
+  fi
+  if ssh_batch "pkg-config --exists zlib 2>/dev/null || test -f /usr/include/zlib.h" &>/dev/null; then
+    ok "zlib dev headers: installed"
+  else
+    err "zlib dev headers still not found after installation."
+    (( post_failed++ )) || true
+  fi
+  if [[ $post_failed -gt 0 ]]; then
+    die "Build toolchain installation incomplete — $post_failed component(s) still missing."
+  fi
+}
+
+# ─── 6. Remote environment verification ───────────────────────────────────────
 verify_remote_environment() {
   step "Verifying remote environment"
 
@@ -288,7 +385,7 @@ verify_remote_environment() {
   fi
 }
 
-# ─── 6. Summary ───────────────────────────────────────────────────────────────
+# ─── 7. Summary ───────────────────────────────────────────────────────────────
 print_summary() {
   echo
   echo -e "${GREEN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
@@ -334,6 +431,7 @@ main() {
   setup_ssh_auth
   $SKIP_SUDO || setup_passwordless_sudo
   verify_remote_environment
+  ensure_build_toolchain
   print_summary
 }
 

--- a/scripts/remote-setup.sh
+++ b/scripts/remote-setup.sh
@@ -1,0 +1,342 @@
+#!/usr/bin/env bash
+# Sets up a remote Linux box so it is ready for benchmark runs — passwordless SSH,
+# passwordless sudo, and verified local prerequisites — without requiring the user
+# to ever log into the box directly.
+#
+# Once this script completes successfully, use scripts/perf-lab/run-benchmarks.sh
+# with --host and --user to run the actual benchmarks.
+#
+# Usage:
+#   scripts/remote-setup.sh --host <HOST> --user <USER> [options]
+#
+# Options:
+#   --host <HOST>      Remote host (domain name or IP)
+#   --user <USER>      Username on the remote host
+#   --ssh-key <PATH>   Path to SSH private key to use/install (auto-detected if omitted)
+#   --ssh-port <PORT>  SSH port on the remote host (default: 22)
+#   --skip-sudo        Skip passwordless sudo setup
+#   --check-only       Verify the setup without making any changes
+#   -h, --help         Show this help message
+
+set -euo pipefail
+
+# ─── Colours ──────────────────────────────────────────────────────────────────
+if [[ -t 1 ]]; then
+  RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+  BLUE='\033[0;34m'; BOLD='\033[1m'; NC='\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; BLUE=''; BOLD=''; NC=''
+fi
+
+info() { echo -e "${BLUE}[INFO]${NC} $*"; }
+ok()   { echo -e "${GREEN}[ OK ]${NC} $*"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+err()  { echo -e "${RED}[FAIL]${NC} $*" >&2; }
+die()  { err "$*"; exit 1; }
+step() { echo; echo -e "${BOLD}━━ $* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"; }
+
+# ─── Defaults ─────────────────────────────────────────────────────────────────
+HOST=""
+REMOTE_USER=""
+SSH_KEY=""
+SSH_PORT="22"
+SKIP_SUDO=false
+CHECK_ONLY=false
+
+# ─── Help ─────────────────────────────────────────────────────────────────────
+help() {
+  cat <<EOF
+
+${BOLD}remote-setup.sh${NC} — Prepare a remote Linux box for benchmark runs.
+
+${BOLD}Usage:${NC}
+  scripts/remote-setup.sh --host <HOST> --user <USER> [options]
+
+${BOLD}Required:${NC}
+  --host <HOST>      Remote host (domain name or IP address)
+  --user <USER>      Username on the remote host
+
+${BOLD}Optional:${NC}
+  --ssh-key <PATH>   Path to SSH private key (auto-detected if omitted)
+  --ssh-port <PORT>  SSH port on the remote host (default: 22)
+  --skip-sudo        Skip passwordless sudo configuration
+  --check-only       Only verify the current setup — make no changes
+  -h, --help         Show this help message
+
+${BOLD}What this script does:${NC}
+  1. Verifies local prerequisites: git, jbang, jq
+  2. Locates (or generates) an SSH key pair
+  3. Installs the public key on the remote host (passwordless SSH login)
+  4. Configures passwordless sudo for the remote user
+  5. Verifies the remote shell environment
+  6. Prints example run-benchmarks.sh commands
+
+${BOLD}After a successful run:${NC}
+  cd scripts/perf-lab
+  ./run-benchmarks.sh --host <HOST> --user <USER> [benchmark options]
+
+EOF
+}
+
+# ─── Argument parsing ─────────────────────────────────────────────────────────
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)    help; exit 0 ;;
+      --host)       HOST="$2";        shift 2 ;;
+      --user)       REMOTE_USER="$2"; shift 2 ;;
+      --ssh-key)    SSH_KEY="$2";     shift 2 ;;
+      --ssh-port)   SSH_PORT="$2";    shift 2 ;;
+      --skip-sudo)  SKIP_SUDO=true;   shift   ;;
+      --check-only) CHECK_ONLY=true;  shift   ;;
+      -*) die "Unknown option: $1 — run with --help for usage." ;;
+      *)  die "Unexpected argument: $1 — run with --help for usage." ;;
+    esac
+  done
+}
+
+validate_args() {
+  [[ -n "$HOST" ]]        || die "--host is required."
+  [[ -n "$REMOTE_USER" ]] || die "--user is required."
+  if [[ -n "$SSH_KEY" && ! -f "$SSH_KEY" ]]; then
+    die "SSH key not found: $SSH_KEY"
+  fi
+}
+
+# ─── SSH helpers ──────────────────────────────────────────────────────────────
+SSH_OPTS=(-o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -p "$SSH_PORT")
+
+ssh_batch() {
+  # Non-interactive SSH — returns non-zero if password is required
+  ssh "${SSH_OPTS[@]}" -o BatchMode=yes "${REMOTE_USER}@${HOST}" "$@"
+}
+
+ssh_interactive() {
+  # Interactive SSH — may prompt for password
+  ssh "${SSH_OPTS[@]}" "${REMOTE_USER}@${HOST}" "$@"
+}
+
+ssh_tty() {
+  # Interactive SSH with allocated tty — needed for sudo password prompts
+  ssh -t "${SSH_OPTS[@]}" "${REMOTE_USER}@${HOST}" "$@"
+}
+
+# ─── 1. Local prerequisites ───────────────────────────────────────────────────
+check_local_prereqs() {
+  step "Checking local prerequisites"
+
+  local missing=()
+
+  if command -v git &>/dev/null; then
+    ok "git $(git --version | awk '{print $3}')"
+  else
+    missing+=("git")
+    err "git not found — install via your package manager or https://git-scm.com"
+  fi
+
+  if command -v jbang &>/dev/null; then
+    ok "jbang $(jbang --version 2>&1 | head -1)"
+  else
+    warn "jbang not found locally — the benchmark wrapper will download it on first run."
+    warn "To install now: curl -Ls https://sh.jbang.dev | bash -s - app setup"
+  fi
+
+  if command -v jq &>/dev/null; then
+    ok "jq $(jq --version)"
+  else
+    missing+=("jq")
+    if [[ "$(uname)" == "Darwin" ]]; then
+      err "jq not found — install with: brew install jq"
+    else
+      err "jq not found — install with: sudo apt-get install jq  (or your distro's equivalent)"
+    fi
+  fi
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    die "Missing required local tools: ${missing[*]}"
+  fi
+}
+
+# ─── 2 & 3. SSH key setup (skipped entirely if login already works) ───────────
+setup_ssh_auth() {
+  step "SSH key authentication"
+
+  if ssh_batch true 2>/dev/null; then
+    ok "Passwordless SSH login already works — skipping key setup."
+    return
+  fi
+
+  if $CHECK_ONLY; then
+    die "Passwordless SSH not configured. Re-run without --check-only to install the key."
+  fi
+
+  # Only locate / generate a key when we actually need to install one
+  if [[ -z "$SSH_KEY" ]]; then
+    local candidates=("$HOME/.ssh/id_ed25519" "$HOME/.ssh/id_ecdsa" "$HOME/.ssh/id_rsa")
+    for k in "${candidates[@]}"; do
+      if [[ -f "$k" ]]; then
+        SSH_KEY="$k"
+        info "Auto-selected key: $SSH_KEY"
+        break
+      fi
+    done
+  fi
+
+  if [[ -z "$SSH_KEY" ]]; then
+    info "No SSH key found — generating ed25519 key pair."
+    ssh-keygen -t ed25519 -f "$HOME/.ssh/id_ed25519" -N "" -C "${REMOTE_USER}@benchmark-setup"
+    SSH_KEY="$HOME/.ssh/id_ed25519"
+    ok "Generated: $SSH_KEY"
+  fi
+
+  info "Installing public key on ${REMOTE_USER}@${HOST}:${SSH_PORT} …"
+  info "(You may be prompted for the remote user's password once.)"
+
+  local pub_key="${SSH_KEY}.pub"
+  [[ -f "$pub_key" ]] || die "Public key not found: $pub_key"
+
+  if command -v ssh-copy-id &>/dev/null; then
+    ssh-copy-id -i "$pub_key" -p "$SSH_PORT" "${REMOTE_USER}@${HOST}"
+  else
+    # Fallback for systems without ssh-copy-id (some macOS setups)
+    local key_content
+    key_content=$(<"$pub_key")
+    ssh "${SSH_OPTS[@]}" "${REMOTE_USER}@${HOST}" \
+      "mkdir -p ~/.ssh && chmod 700 ~/.ssh && echo '${key_content}' >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
+  fi
+
+  # Verify
+  if ssh_batch true 2>/dev/null; then
+    ok "Passwordless SSH login confirmed."
+  else
+    die "SSH key installation appeared to succeed but passwordless login still fails. Check sshd_config on the remote host (PubkeyAuthentication must be 'yes')."
+  fi
+}
+
+# ─── 4. Passwordless sudo ─────────────────────────────────────────────────────
+setup_passwordless_sudo() {
+  step "Passwordless sudo"
+
+  if ssh_batch "sudo -n true" 2>/dev/null; then
+    ok "Passwordless sudo already configured."
+    return
+  fi
+
+  if $CHECK_ONLY; then
+    die "Passwordless sudo not configured. Re-run without --check-only to configure it."
+  fi
+
+  info "Configuring passwordless sudo for '${REMOTE_USER}' on ${HOST} …"
+  info "(You will be prompted for the remote user's sudo password.)"
+
+  local sudoers_file="/etc/sudoers.d/${REMOTE_USER}-nopasswd"
+  local sudoers_entry="${REMOTE_USER} ALL=(ALL) NOPASSWD: ALL"
+
+  # We need a tty here so sudo can prompt for its password
+  ssh_tty "echo '${sudoers_entry}' | sudo tee '${sudoers_file}' > /dev/null && sudo chmod 0440 '${sudoers_file}' && sudo visudo -c -q"
+
+  # Verify
+  if ssh_batch "sudo -n true" 2>/dev/null; then
+    ok "Passwordless sudo confirmed."
+  else
+    die "Passwordless sudo configuration failed. Manually verify ${sudoers_file} on the remote host."
+  fi
+}
+
+# ─── 5. Remote environment verification ───────────────────────────────────────
+verify_remote_environment() {
+  step "Verifying remote environment"
+
+  local checks_failed=0
+
+  # bash
+  local remote_bash
+  if remote_bash=$(ssh_batch "bash --version 2>/dev/null | head -1" 2>/dev/null); then
+    ok "bash: $remote_bash"
+  else
+    err "bash not found on remote host — this is required."
+    (( checks_failed++ )) || true
+  fi
+
+  # OS type
+  local remote_os
+  if remote_os=$(ssh_batch "uname -sr" 2>/dev/null); then
+    ok "OS: $remote_os"
+    if [[ "$remote_os" != Linux* ]]; then
+      warn "Remote host does not appear to be Linux. Only Linux is supported for benchmarks."
+    fi
+  fi
+
+  # curl (needed for SDKMAN, jbang, etc.)
+  if ssh_batch "command -v curl" &>/dev/null; then
+    ok "curl: present"
+  else
+    err "curl not found on the remote host. Install it before running benchmarks (e.g. sudo apt-get install curl)."
+    (( checks_failed++ )) || true
+  fi
+
+  # Check that the benchmark runner can SSH back in non-interactively (qDup requirement)
+  if ssh_batch "echo 'connectivity ok'" &>/dev/null; then
+    ok "Non-interactive SSH round-trip: ok"
+  else
+    err "Non-interactive SSH round-trip failed."
+    (( checks_failed++ )) || true
+  fi
+
+  if [[ $checks_failed -gt 0 ]]; then
+    die "$checks_failed remote environment check(s) failed. Fix the issues above and re-run."
+  fi
+}
+
+# ─── 6. Summary ───────────────────────────────────────────────────────────────
+print_summary() {
+  echo
+  echo -e "${GREEN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+  echo -e "${GREEN}${BOLD}  Setup complete!${NC}"
+  echo -e "${GREEN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+  echo
+  echo -e "  ${BOLD}Remote host:${NC} ${REMOTE_USER}@${HOST}:${SSH_PORT}"
+  [[ -n "$SSH_KEY" ]] && echo -e "  ${BOLD}SSH key:${NC}     $SSH_KEY"
+  echo
+  echo -e "  ${BOLD}Run benchmarks from the perf-lab directory:${NC}"
+  echo
+  echo -e "    cd scripts/perf-lab"
+  echo
+  echo -e "  ${BOLD}All runtimes (JVM + native):${NC}"
+  echo    "    ./run-benchmarks.sh \\"
+  echo    "      --host ${HOST} \\"
+  echo    "      --user ${REMOTE_USER} \\"
+  echo    "      --quarkus-version <VERSION> \\"
+  echo    "      --springboot3-version <VERSION>"
+  echo
+  echo -e "  ${BOLD}JVM runtimes only (faster):${NC}"
+  echo    "    ./run-benchmarks.sh \\"
+  echo    "      --host ${HOST} \\"
+  echo    "      --user ${REMOTE_USER} \\"
+  echo    "      --runtimes 'quarkus3-jvm,spring3-jvm,spring4-jvm,dotnet10' \\"
+  echo    "      --quarkus-version <VERSION> \\"
+  echo    "      --springboot3-version <VERSION>"
+  echo
+  echo -e "  See ${BOLD}./run-benchmarks.sh --help${NC} for all options."
+  echo
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+main() {
+  echo
+  echo -e "${BOLD}remote-setup.sh — Remote Benchmark Host Setup${NC}"
+  echo -e "Host: ${HOST}  User: ${REMOTE_USER}  Port: ${SSH_PORT}"
+  if $CHECK_ONLY; then
+    echo -e "${YELLOW}[check-only mode — no changes will be made]${NC}"
+  fi
+
+  check_local_prereqs
+  setup_ssh_auth
+  $SKIP_SUDO || setup_passwordless_sudo
+  verify_remote_environment
+  print_summary
+}
+
+parse_args "$@"
+validate_args
+main

--- a/scripts/stress.sh
+++ b/scripts/stress.sh
@@ -44,7 +44,16 @@ ts=$(_date)
 # On Spring with virtual threads, tomcat fully run it, and they handle blocking calls there too, meaning that the total number of platform threads honor -XX:ActiveProcessorCount
 #
 # When running in the lab environment (see perf-lab/run-benchmarks.sh & perf-lab/main.yml), this is taken care of by using taskset on Linux.
-java -XX:ActiveProcessorCount=4 -Xms512m -Xmx512m -jar ${callingdir}/$1 &
+if [[ "$1" != *.jar ]]; then
+  # .NET: use DOTNET_* env vars to approximate Java -Xmx and -XX:ActiveProcessorCount
+  export DOTNET_GCHeapHardLimit=0x20000000
+  export DOTNET_ProcessorCount=4
+  export DOTNET_gcServer=1
+  export Logging__LogLevel__Default=None
+  ${callingdir}/$1 &
+else
+  java -XX:ActiveProcessorCount=4 -Xms512m -Xmx512m -jar ${callingdir}/$1 &
+fi
 CURRENT_PID=$!
 
 # Wait and measure TTFR


### PR DESCRIPTION
## Summary

Adds a .NET 10 implementation (`dotnet10/`) equivalent to the existing Quarkus 3 and Spring Boot
implementations, along with full perf-lab and CI integration.

### Application (`dotnet10/`)

Same domain model, endpoints, and behaviour as the Quarkus implementation:

| Concept | Quarkus 3 | dotnet10 |
|---|---|---|
| HTTP framework | RESTEasy (JAX-RS) | ASP.NET Core Minimal API |
| ORM | Hibernate ORM Panache | EF Core + Npgsql |
| Health checks | SmallRye Health | `AddHealthChecks().AddDbContextCheck<T>()` |
| Metrics | Micrometer → OTel OTLP | OTel `WithMetrics` → OTLP |
| Traces | SmallRye OTel, 10% sampling | OTel `TraceIdRatioBasedSampler(0.1)` |
| JSON | Jackson | `System.Text.Json` (source-generated, AOT-safe) |
| HTTP port | 8080 | 8080 |

The app emits a startup log matching the perf-lab `logFileStartedRegex` pattern
(`.*dotnet10.+started in.*`).

### perf-lab integration

- `scripts/perf-lab/main.yml` — `dotnet10` entry in `RUNTIMES` and `RUNTIMECMDS`;
  `updateScript: skip-version-update` prevents abort when qDup's `update-runtime-version` runs.
  `runCmd` uses `env KEY=value` prefix so that `time-to-1st-request.sh`'s `exec $RUN_CMD`
  correctly word-splits env-var assignments vs. the binary.
- `scripts/perf-lab/run-benchmarks.sh` — `dotnet10` in `ALLOWED_RUNTIMES` / `DEFAULT_RUNTIMES`;
  `xmx_to_dotnet_gc_limit()` converts `--jvm-memory` (e.g. `-Xmx512m`) to a hex
  `DOTNET_GCHeapHardLimit` so memory constraints match the JVM exactly.
- `scripts/perf-lab/helpers/dotnet.yml` / `requirements.yml` — `ensure-dotnet` requirement check.
- Runtime constraints are equivalent to the JVM runtimes:
  - CPU pinning via `taskset` (`APP_CMD_PREFIX`)
  - `DOTNET_GCHeapHardLimit` computed from `--jvm-memory`
  - `DOTNET_ProcessorCount` from `--cpus-app`
  - `DOTNET_gcServer=1`

### CI (`.github/workflows/main.yml`)

New `dotnet-build-test` job that builds the app and runs unit tests (E2E tests excluded
pending a database service container — see open items).

### Scripts

- `scripts/stress.sh` and `scripts/1strequest.sh` — detect dotnet binaries and set the correct
  runtime env vars. `1strequest.sh` also gains a `--no-purge` flag to skip `sudo purge`/
  `drop_caches` for local dev use without sudo.
- `scripts/remote-setup.sh` — one-command preparation of a bare Linux benchmark host
  (SSH key install, passwordless sudo, environment verification).

### Docs

- `DOTNET-PORTING.md` — Quarkus→dotnet concept mapping table, implementation status,
  native AOT blocker rationale, and checklist for adding future dotnet versions.
- `README.md` — dotnet10 entry, remote benchmark workflow, script examples.

## Benchmark results while end-to-end testing

on a Hetzner CPX62 VPS, 16-core / 30 GB, 512 MB heap limit

```bash
./run-benchmarks.sh \
  --runtimes 'dotnet10' \
  --repo-url https://github.com/cdhermann/spring-quarkus-perf-comparison.git \
  --host quarkus-dotnet-performance-comparison \
  --user root \
  --cpus-app 0-3 \
  --cpus-db 4-6 \
  --cpus-otel 7-9 \
  --cpus-load-gen 10-12 \
  --cpus-monitoring 13 \
  --cpus-first-request 10
 ```
 
and

```bash
./run-benchmarks.sh \
  --runtimes 'quarkus3-jvm' \
  --repo-url https://github.com/cdhermann/spring-quarkus-perf-comparison.git \
  --host quarkus-dotnet-performance-comparison \
  --user root \
  --quarkus-version 3.34.5 \
  --cpus-app 0-3 \
  --cpus-db 4-6 \
  --cpus-otel 7-9 \
  --cpus-load-gen 10-12 \
  --cpus-monitoring 13 \
  --cpus-first-request 10
  ```

| Metric | dotnet10 | Quarkus 3 JVM |
|---|---|---|
| Build time | **2.2s** | 9.0s |
| Startup (TTFR) | **1711ms** | 2578ms |
| RSS at startup | **69 MiB** | 275 MiB |
| RSS after 1st request | **129 MiB** | 292 MiB |
| RSS under load | **225 MiB** | 772 MiB |
| Throughput | 6582 tps | **18176 tps** |
| Throughput density | **29.3 tps/MiB** | 23.9 tps/MiB |
| Errors | 0 | 0 |

## Open items (not blocking)

- **E2E tests require a running database.** Unit tests pass in CI. E2E tests are excluded
  with `--filter "FullyQualifiedName!~Dotnet10.Tests.E2e"` until either Testcontainers or a
  GitHub Actions service container is wired up.
- **Dependabot NuGet monitoring.** `.github/dependabot.yml` currently only covers Maven.
  A follow-up can add a `nuget` entry pointing at `dotnet10/`.
- **dotnet-native is not feasible yet.** EF Core Native AOT support is still experimental
  upstream ([dotnet/efcore#29840](https://github.com/dotnet/efcore/issues/29840)).
  A `dotnet10-native` runtime will be added once that stabilises.
- **`java -version` calls in perf-lab are misleading for dotnet runtimes** — harmless noise
  since Java is always present (qDup is a Java tool), but could be made conditional on
  `${{RUNTIME.type}} != dotnet` in a follow-up.

---

> **AI disclosure:** Much of this implementation was developed with Claude (Anthropic).
> The code, script changes, and benchmark methodology have been tested end-to-end, but
> human review is warmly welcomed — particularly on the perf-lab integration and runtime
> constraint parity between JVM and .NET.