### PR TITLE
Fix benchmark-orchestrator image build on linux/arm64

### DIFF
--- a/.github/workflows/build-publish-qdup-ghcr.yml
+++ b/.github/workflows/build-publish-qdup-ghcr.yml
@@ -44,6 +44,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Sanitize tag
+        id: tag
+        run: echo "value=$(echo '${{ github.ref_name }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+
       - name: Build and push images
         uses: docker/build-push-action@v7
         with:
@@ -52,4 +56,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           load: false
-          tags: ghcr.io/${{ github.repository_owner }}/benchmark-orchestrator:${{ github.ref_name }}
+          tags: ghcr.io/${{ github.repository_owner }}/benchmark-orchestrator:${{ steps.tag.outputs.value }}

--- a/.github/workflows/syncbot.yml
+++ b/.github/workflows/syncbot.yml
@@ -147,8 +147,7 @@ jobs:
           fi
 
       - name: Update PR comment on success
-        if: steps.push-and-pr.outputs.push_failed_workflows != 'true' && steps.cherry-pick.outputs.skipped_commits == ''
-        if: steps.cherry-pick.outputs.all_skipped != 'true' && steps.cherry-pick.outputs.skipped_commits == ''
+        if: steps.push-and-pr.outputs.push_failed_workflows != 'true' && steps.cherry-pick.outputs.all_skipped != 'true' && steps.cherry-pick.outputs.skipped_commits == ''
         uses: quarkusio/action-helpers@main
         with:
           action: maintain-one-comment

--- a/scripts/perf-lab/benchmark-orchestrator.Dockerfile
+++ b/scripts/perf-lab/benchmark-orchestrator.Dockerfile
@@ -3,8 +3,10 @@ LABEL org.opencontainers.image.source="https://github.com/quarkusio/spring-quark
 
 USER root
 
-# Install system dependencies and container runtime
-RUN dnf install -y --allowerasing gcc zlib-devel git procps-ng curl file bash unzip zip sudo podman fuse-overlayfs slirp4netns shadow-utils
+# Install system dependencies, container runtime, and Java 21
+# Java installed via dnf so both amd64 and arm64 get native packages —
+# prevents JBang from downloading its own JDK (which fails on arm64).
+RUN dnf install -y --allowerasing gcc zlib-devel git procps-ng curl file bash unzip zip sudo podman fuse-overlayfs slirp4netns shadow-utils java-21-openjdk-devel
 
 # Set up subuid and subgid for rootless containers BEFORE creating user
 RUN touch /etc/subuid /etc/subgid && \
@@ -32,12 +34,10 @@ RUN . ~/.nvm/nvm.sh && \
     nvm install --lts && \
     nvm use --lts
 
-# Install jbang
-RUN curl -Ls https://sh.jbang.dev | bash -s - app setup
-
-# Install sdkman
-RUN curl -s "https://get.sdkman.io" | bash && \
-    source "$HOME/.sdkman/bin/sdkman-init.sh"
+# Install SDKMAN, then use it to install JBang
+# SDKMAN handles arm64 natively; no separate JDK download needed (system Java 21 is used)
+RUN curl -s "https://get.sdkman.io" | bash
+RUN bash -c "source ~/.sdkman/bin/sdkman-init.sh && sdk install jbang"
 
 # Configure homebrew
 # ENV HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew \


### PR DESCRIPTION
JBang's curl installer downloads JDK 17 on its own which consistently fails on arm64 GitHub runners. Also adds tag sanitization to the workflow so branch names containing slashes produce valid Docker image tags.

- Add java-21-openjdk-devel to the dnf install step (UBI9 native package, works on both amd64 and arm64)
- Install JBang via SDKMAN instead of the curl installer — SDKMAN is already present, handles arm64 natively, no separate JDK download needed
- Sanitize github.ref_name before using it as a Docker image tag (slashes in branch names are invalid in image tag references)