### PR TITLE
Support native builds with Mandrel and fix load-test race conditions for extremely fast native startup

### DIFF
--- a/.github/workflows/syncbot.yml
+++ b/.github/workflows/syncbot.yml
@@ -147,8 +147,7 @@ jobs:
           fi
 
       - name: Update PR comment on success
-        if: steps.push-and-pr.outputs.push_failed_workflows != 'true' && steps.cherry-pick.outputs.skipped_commits == ''
-        if: steps.cherry-pick.outputs.all_skipped != 'true' && steps.cherry-pick.outputs.skipped_commits == ''
+        if: steps.push-and-pr.outputs.push_failed_workflows != 'true' && steps.cherry-pick.outputs.all_skipped != 'true' && steps.cherry-pick.outputs.skipped_commits == ''
         uses: quarkusio/action-helpers@main
         with:
           action: maintain-one-comment

--- a/scripts/perf-lab/helpers/java.yml
+++ b/scripts/perf-lab/helpers/java.yml
@@ -29,6 +29,45 @@ scripts:
     - log: Showing GraalVM version
     - sh: $GRAALVM_HOME/bin/java -version
 
+  ensure-mandrel:
+    - sh: echo "${{config.jvm.mandrel.home:}}"
+      then:
+        - regex: ^$
+          then:
+            - sh: echo "${{config.jvm.mandrel.version:}}"
+              then:
+                - regex: ^$
+                  then:
+                    - log: No Mandrel version or home configured — skipping Mandrel setup
+                  else:
+                    # No local Mandrel path provided, use SDKMAN
+                    - script: sdk-select-java
+                      with:
+                        java_version: ${{config.jvm.mandrel.version}}
+                        install_if_missing: true
+                    - log: Setting MANDREL_HOME from SDKMAN
+                    - sh: export MANDREL_HOME=$(sdk home java ${{config.jvm.mandrel.version}})
+          else:
+            # Local Mandrel path provided
+            - log: Using locally installed Mandrel from ${{config.jvm.mandrel.home}}
+            - sh: export MANDREL_HOME=${{config.jvm.mandrel.home}}
+            - sh: test -d "$MANDREL_HOME"
+              then:
+                - regex: ".*"
+                  else:
+                    - abort: Mandrel home directory does not exist at ${{config.jvm.mandrel.home}}
+            - sh: test -x "$MANDREL_HOME/bin/native-image"
+              then:
+                - regex: ".*"
+                  else:
+                    - abort: Mandrel native-image executable not found or not executable at ${{config.jvm.mandrel.home}}/bin/native-image
+    - sh: echo "${{config.jvm.mandrel.version:}}${{config.jvm.mandrel.home:}}"
+      then:
+        - regex: ^$
+          else:
+            - log: Showing Mandrel version
+            - sh: $MANDREL_HOME/bin/java -version
+
   ensure-java:
     - sh: echo "${{config.jvm.home:}}"
       then:

--- a/scripts/perf-lab/helpers/requirements.yml
+++ b/scripts/perf-lab/helpers/requirements.yml
@@ -2,6 +2,7 @@ name: Requirements needed to run benchmarks
 scripts:
   ensure-requirements:
     - script: ensure-graalvm
+    - script: ensure-mandrel
     - script: ensure-java
     - script: ensure-git
     - script: ensure-gcc

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -735,6 +735,7 @@ scripts:
         - regex: "${{log_regex}}"
           then:
             - ctrlC
+            - sleep: 1s # give the main thread time to register wait-for before the signal fires
             - signal: LOG_REGEX_REACHED
       timer:
         1m:

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -597,6 +597,16 @@ scripts:
         - script: sync-drop-fs-cache
         - set-signal: LOAD_STEADY_STATE_START 1
         - set-signal: LOG_REGEX_REACHED 1
+        - script:
+            # Start watch-log BEFORE the app so tail -f sees output as new lines.
+            # If watch-log is started after the app, tail reads the already-written
+            # "started" message as existing file content and fires the signal before
+            # the app is truly serving traffic (or before wrk has started).
+            name: watch-log
+            async: true
+          with:
+            log_file: ${{LOG_FILE}}
+            log_regex: ${{APP_LOG_REGEX}}
         - read-state: ${{config.profiler.name}}
           then:
             - regex: "^syncjfr$"
@@ -637,12 +647,6 @@ scripts:
                     format: ${{config.profiler.name}}
                     events: ${{config.profiler.events}}
                     delay: 10s
-        - script:
-            name: watch-log
-            async: true
-          with:
-            log_file: ${{LOG_FILE}}
-            log_regex: ${{APP_LOG_REGEX}}
         - wait-for: LOG_REGEX_REACHED
         - sh: ${{RUN.WRK_BIN}} -t 2 -c 100 -d 2m --timeout 2m ${{TARGET_URL}} 2>&1 >${{REPO_DIR}}/logs/wrk-warmup-${{RUNTIMECMD.name}}-${{ITERATION}}.log
         - regex: unable to connect
@@ -735,7 +739,6 @@ scripts:
         - regex: "${{log_regex}}"
           then:
             - ctrlC
-            - sleep: 1s # give the main thread time to register wait-for before the signal fires
             - signal: LOG_REGEX_REACHED
       timer:
         1m:

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -19,6 +19,8 @@ states:
   config.jvm.version: 25.0.2-tem
   config.jvm.graalvm.home: #/path/to/graalvm
   config.jvm.graalvm.version: 25.0.2-graalce
+  config.jvm.mandrel.home: #/path/to/mandrel
+  config.jvm.mandrel.version: #24.1.2.r23-mandrel
 
   config.quarkus.version: #3.28.3
   config.springboot3.version: #3.5.6
@@ -104,6 +106,17 @@ states:
       logFileStartedRegex: ".*quarkus3.+started in.*"
     - name: quarkus3-native
       type: native
+      nativeTool: graalvm
+      dir: ${{QUARKUS3_DIR}}
+      updateScript: update-quarkus-version
+      updateVersion: ${{config.quarkus.version}}
+      buildRequiresTestServices: false
+      buildCmd: "${{APP_CMD_PREFIX}} ./mvnw ${{config.quarkus.build_config_args}} clean package -DskipTests -Pnative ${{config.quarkus.native_build_options}}"
+      runCmd: "${{APP_CMD_PREFIX}} ${{RUNTIME_BUILD_DIR}}/quarkus3-runner ${{config.jvm.memory}}"
+      logFileStartedRegex: ".*quarkus3.+started in.*"
+    - name: quarkus3-native-mandrel
+      type: native
+      nativeTool: mandrel
       dir: ${{QUARKUS3_DIR}}
       updateScript: update-quarkus-version
       updateVersion: ${{config.quarkus.version}}
@@ -395,7 +408,15 @@ scripts:
     - sh: cd ${{RUNTIMECMD.dir}}
     - log: JVM version
     - sh: java -version
-    - log: GraalVM Version
+    # Switch GRAALVM_HOME to the native image tool appropriate for this runtime
+    - read-state: ${{RUNTIMECMD.nativeTool:graalvm}}
+      then:
+        - regex: mandrel
+          then:
+            - sh: export GRAALVM_HOME=$MANDREL_HOME
+          else:
+            - sh: export GRAALVM_HOME=$GRAALVM_HOME
+    - log: Native image tool version
     - sh: $GRAALVM_HOME/bin/java -version
     - set-state: TYPE ${{RUNTIMECMD.type}}
     - for-each: ITERATION ${{=[...Array(${{config.num_iterations}}).keys()]}}

--- a/scripts/perf-lab/run-benchmarks.sh
+++ b/scripts/perf-lab/run-benchmarks.sh
@@ -40,11 +40,17 @@ help() {
   echo "  --drop-fs-caches                                        Purge/drop OS filesystem caches between iterations"
   echo "  --extra-qdup-args <EXTRA_QDUP_ARGS>                     Any extra arguments that need to be passed to qDup ahead of the qDup scripts"
   echo "                                                              NOTE: This is an advanced option. Make sure you know what you are doing when using it."
-  echo "  --graalvm-home <GRAALVM_HOME>                           Path to a locally installed GraalVM/Mandrel distribution"
+  echo "  --graalvm-home <GRAALVM_HOME>                           Path to a locally installed GraalVM distribution"
   echo "                                                              If set, this takes precedence over --graalvm-version"
-  echo "  --graalvm-version <GRAALVM_VERSION>                     The GraalVM version to use if running any native tests (from SDKMAN)"
+  echo "  --graalvm-version <GRAALVM_VERSION>                     The GraalVM version to use for quarkus3-native (from SDKMAN)"
   echo "                                                              Default: ${GRAALVM_VERSION}"
   echo "                                                              Ignored if --graalvm-home is set"
+  echo "  --mandrel-home <MANDREL_HOME>                           Path to a locally installed Mandrel distribution"
+  echo "                                                              If set, this takes precedence over --mandrel-version"
+  echo "  --mandrel-version <MANDREL_VERSION>                     The Mandrel version to use for quarkus3-native-mandrel (from SDKMAN)"
+  echo "                                                              Required when running quarkus3-native-mandrel"
+  echo "                                                              Default: ${MANDREL_VERSION}"
+  echo "                                                              Ignored if --mandrel-home is set"
   echo "  --host <HOST>                                           The HOST to run the benchmarks on"
   echo "                                                              LOCAL is a keyword that can be used to run everything on the local machine"
   echo "                                                              Default: ${HOST}"
@@ -142,6 +148,8 @@ print_values() {
   echo "  CPUS_FIRST_REQUEST=$CPUS_FIRST_REQUEST"
   echo "  GRAALVM_HOME: $GRAALVM_HOME"
   echo "  GRAALVM_VERSION: $GRAALVM_VERSION"
+  echo "  MANDREL_HOME: $MANDREL_HOME"
+  echo "  MANDREL_VERSION: $MANDREL_VERSION"
   echo "  HOST: $HOST"
   echo "  ITERATIONS: $ITERATIONS"
   echo "  JAVA_HOME: $JAVA_HOME"
@@ -270,6 +278,8 @@ ${JBANG_CMD} io.hyperfoil.tools:qDup:0.11.0 \
     ./helpers/ \
     -S config.jvm.graalvm.home="${GRAALVM_HOME}" \
     -S config.jvm.graalvm.version=${GRAALVM_VERSION} \
+    -S config.jvm.mandrel.home="${MANDREL_HOME}" \
+    -S config.jvm.mandrel.version="${MANDREL_VERSION}" \
     -S config.jvm.home="${JAVA_HOME}" \
     -S config.jvm.version=${JAVA_VERSION} \
     -S config.quarkus.native_build_options="${NATIVE_QUARKUS_BUILD_OPTIONS}" \
@@ -325,6 +335,8 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   SCENARIO_SET_BY_USER=""
   GRAALVM_HOME=""
   GRAALVM_VERSION="25.0.2-graalce"
+  MANDREL_HOME=""
+  MANDREL_VERSION=""
   HOST="LOCAL"
   ITERATIONS="3"
   JAVA_HOME=""
@@ -335,7 +347,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   PROFILER="none"
   QUARKUS_BUILD_CONFIG_ARGS=""
   QUARKUS_VERSION=""
-  ALLOWED_RUNTIMES=("quarkus3-jvm" "quarkus3-leyden" "quarkus3-virtual" "quarkus3-virtual-leyden" "quarkus3-native" "spring3-jvm" "spring3-leyden" "spring3-virtual" "spring3-virtual-leyden" "spring3-jvm-aot" "spring3-native" "spring4-jvm" "spring4-leyden" "spring4-virtual" "spring4-virtual-leyden" "spring4-jvm-aot" "spring4-native")
+  ALLOWED_RUNTIMES=("quarkus3-jvm" "quarkus3-leyden" "quarkus3-virtual" "quarkus3-virtual-leyden" "quarkus3-native" "quarkus3-native-mandrel" "spring3-jvm" "spring3-leyden" "spring3-virtual" "spring3-virtual-leyden" "spring3-jvm-aot" "spring3-native" "spring4-jvm" "spring4-leyden" "spring4-virtual" "spring4-virtual-leyden" "spring4-jvm-aot" "spring4-native")
   DEFAULT_RUNTIMES=("quarkus3-jvm" "quarkus3-leyden" "quarkus3-virtual" "quarkus3-virtual-leyden" "quarkus3-native" "spring3-jvm" "spring3-leyden" "spring3-virtual" "spring3-virtual-leyden" "spring3-native" "spring4-jvm" "spring4-leyden" "spring4-virtual" "spring4-virtual-leyden" "spring4-native")
   RUNTIMES=${DEFAULT_RUNTIMES[@]}
   SPRING_BOOT3_VERSION=""
@@ -407,6 +419,16 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 
       --graalvm-version)
         GRAALVM_VERSION="$2"
+        shift 2
+        ;;
+
+      --mandrel-home)
+        MANDREL_HOME="$2"
+        shift 2
+        ;;
+
+      --mandrel-version)
+        MANDREL_VERSION="$2"
         shift 2
         ;;
 


### PR DESCRIPTION
## Description

### Overview

This PR adds support for building Quarkus native images with **Mandrel** alongside the existing GraalVM CE support. It also includes bug fixes for load-testing race conditions that were affecting benchmark measurement accuracy.

### Changes

- **9db0000**: Support native builds with Mandrel next to GraalVM
  - Adds Mandrel as an alternative native image compiler option
  - Maintains compatibility with existing GraalVM CE builds
  
- **49c1308**: Fix race condition in watch-log (async startup detection)
  - Native Quarkus binaries start in ~80ms, fast enough that the async watch-log script could fire `LOG_REGEX_REACHED` before the main thread registered its `wait-for`
  - Added 1s sleep between ctrlC and signal to ensure main thread registration

- **5b9739b**: Fix duplicate 'if' key in syncbot.yml (GitHub Actions validation)

- **da68703**: Fix load-test watch-log race (timing issue)
  - Moved watch-log invocation to **before** app start
  - Previously, tail -f would replay existing log content when the app had already started, causing regex to fire instantly and skewing results
  - Removed ineffective 1s sleep from watch-log callback

### Benchmark Findings

Related work on <https://github.com/cdhermann/spring-quarkus-perf-comparison/tree/native-mandrel-with-dotnet> branch includes:

- Demo benchmarking comparing GraalVM CE vs. Mandrel with .NET 10 integration
- **Key Finding**: GraalVM CE and Mandrel perform **equally well** in throughput and startup time metrics
- **Interesting Discovery**: Mandrel's reachable field, reflection types, reflection methods analysis detects **one less** compared to GraalVM CE; see <https://github.com/cdhermann/spring-quarkus-perf-comparison/blob/native-mandrel-with-dotnet/docs/benchmark-runs/results-quarkus-all-JDK25_and_dotnet10-7x-2026-04-27.md#native-image-statistics>

### Testing

- Verify native builds work with both GraalVM CE and Mandrel backends
- Run full load test suite to confirm race condition fixes don't impact measurements
- Validate log-based startup detection with fast-starting native binaries