### PR TITLE
Use BigDecimal instead of float for price in StoreFruitPriceDTO

### DIFF
--- a/quarkus3-spring-compatibility/src/main/java/org/acme/dto/StoreFruitPriceDTO.java
+++ b/quarkus3-spring-compatibility/src/main/java/org/acme/dto/StoreFruitPriceDTO.java
@@ -1,8 +1,10 @@
 package org.acme.dto;
 
-public record StoreFruitPriceDTO(StoreDTO store, float price) {
+import java.math.BigDecimal;
+
+public record StoreFruitPriceDTO(StoreDTO store, BigDecimal price) {
   public StoreFruitPriceDTO {
-    if (price < 0) {
+    if ((price != null) && (price.signum() < 0)) {
       throw new IllegalArgumentException("Price must be >= 0");
     }
   }

--- a/quarkus3-spring-compatibility/src/main/java/org/acme/mapping/StoreFruitPriceMapper.java
+++ b/quarkus3-spring-compatibility/src/main/java/org/acme/mapping/StoreFruitPriceMapper.java
@@ -13,7 +13,7 @@ public final class StoreFruitPriceMapper {
 
     return new StoreFruitPriceDTO(
         StoreMapper.map(storeFruitPrice.getStore()),
-        storeFruitPrice.getPrice().floatValue()
+        storeFruitPrice.getPrice()
     );
   }
 }

--- a/quarkus3-virtual/src/main/java/org/acme/dto/StoreFruitPriceDTO.java
+++ b/quarkus3-virtual/src/main/java/org/acme/dto/StoreFruitPriceDTO.java
@@ -1,8 +1,10 @@
 package org.acme.dto;
 
-public record StoreFruitPriceDTO(StoreDTO store, float price) {
+import java.math.BigDecimal;
+
+public record StoreFruitPriceDTO(StoreDTO store, BigDecimal price) {
   public StoreFruitPriceDTO {
-    if (price < 0) {
+    if ((price != null) && (price.signum() < 0)) {
       throw new IllegalArgumentException("Price must be >= 0");
     }
   }

--- a/quarkus3-virtual/src/main/java/org/acme/mapping/StoreFruitPriceMapper.java
+++ b/quarkus3-virtual/src/main/java/org/acme/mapping/StoreFruitPriceMapper.java
@@ -13,7 +13,7 @@ public final class StoreFruitPriceMapper {
 
     return new StoreFruitPriceDTO(
         StoreMapper.map(storeFruitPrice.getStore()),
-        storeFruitPrice.getPrice().floatValue()
+        storeFruitPrice.getPrice()
     );
   }
 }

--- a/quarkus3/src/main/java/org/acme/dto/StoreFruitPriceDTO.java
+++ b/quarkus3/src/main/java/org/acme/dto/StoreFruitPriceDTO.java
@@ -1,8 +1,10 @@
 package org.acme.dto;
 
-public record StoreFruitPriceDTO(StoreDTO store, float price) {
+import java.math.BigDecimal;
+
+public record StoreFruitPriceDTO(StoreDTO store, BigDecimal price) {
   public StoreFruitPriceDTO {
-    if (price < 0) {
+    if ((price != null) && (price.signum() < 0)) {
       throw new IllegalArgumentException("Price must be >= 0");
     }
   }

--- a/quarkus3/src/main/java/org/acme/mapping/StoreFruitPriceMapper.java
+++ b/quarkus3/src/main/java/org/acme/mapping/StoreFruitPriceMapper.java
@@ -13,7 +13,7 @@ public final class StoreFruitPriceMapper {
 
     return new StoreFruitPriceDTO(
         StoreMapper.map(storeFruitPrice.getStore()),
-        storeFruitPrice.getPrice().floatValue()
+        storeFruitPrice.getPrice()
     );
   }
 }

--- a/springboot3/src/main/java/org/acme/dto/StoreFruitPriceDTO.java
+++ b/springboot3/src/main/java/org/acme/dto/StoreFruitPriceDTO.java
@@ -1,8 +1,10 @@
 package org.acme.dto;
 
-public record StoreFruitPriceDTO(StoreDTO store, float price) {
+import java.math.BigDecimal;
+
+public record StoreFruitPriceDTO(StoreDTO store, BigDecimal price) {
   public StoreFruitPriceDTO {
-    if (price < 0) {
+    if ((price != null) && (price.signum() < 0)) {
       throw new IllegalArgumentException("Price must be >= 0");
     }
   }

--- a/springboot3/src/main/java/org/acme/mapping/StoreFruitPriceMapper.java
+++ b/springboot3/src/main/java/org/acme/mapping/StoreFruitPriceMapper.java
@@ -13,7 +13,7 @@ public final class StoreFruitPriceMapper {
 
     return new StoreFruitPriceDTO(
         StoreMapper.map(storeFruitPrice.getStore()),
-        storeFruitPrice.getPrice().floatValue()
+        storeFruitPrice.getPrice()
     );
   }
 }

--- a/springboot4/src/main/java/org/acme/dto/StoreFruitPriceDTO.java
+++ b/springboot4/src/main/java/org/acme/dto/StoreFruitPriceDTO.java
@@ -1,8 +1,10 @@
 package org.acme.dto;
 
-public record StoreFruitPriceDTO(StoreDTO store, float price) {
+import java.math.BigDecimal;
+
+public record StoreFruitPriceDTO(StoreDTO store, BigDecimal price) {
   public StoreFruitPriceDTO {
-    if (price < 0) {
+    if ((price != null) && (price.signum() < 0)) {
       throw new IllegalArgumentException("Price must be >= 0");
     }
   }

--- a/springboot4/src/main/java/org/acme/mapping/StoreFruitPriceMapper.java
+++ b/springboot4/src/main/java/org/acme/mapping/StoreFruitPriceMapper.java
@@ -13,7 +13,7 @@ public final class StoreFruitPriceMapper {
 
     return new StoreFruitPriceDTO(
         StoreMapper.map(storeFruitPrice.getStore()),
-        storeFruitPrice.getPrice().floatValue()
+        storeFruitPrice.getPrice()
     );
   }
 }


### PR DESCRIPTION
## Summary

- Change `StoreFruitPriceDTO.price` from `float` to `BigDecimal` across all 5 modules
- Remove lossy `.floatValue()` call in `StoreFruitPriceMapper` — pass `BigDecimal` through directly
- Update validation to use `BigDecimal.signum()` instead of `< 0` comparison

This eliminates the lossy `BigDecimal→float` narrowing conversion that caused monetary values like `1.29` to serialize as `1.2899999618530273`. The entity and database already use `BigDecimal`/`NUMERIC`, so the DTO now matches the rest of the stack.

Closes #513

## Test plan

- [x] `./mvnw clean verify` passes across all modules
- [x] Start app + PostgreSQL, hit the REST endpoint, and confirm prices render as exact decimals (e.g. `1.29` not `1.2899999...`)