### PR TITLE
[OOTB] Create hyperfoil yaml rather than running wrk directly

### DIFF
--- a/scripts/infra.sh
+++ b/scripts/infra.sh
@@ -136,7 +136,7 @@ else
 fi
 
 # Process the input options
-while getopts "c:dhm:p:rs" option; do
+while getopts "c:dhnm:p:rs" option; do
   case $option in
     c) CPUS=$OPTARG
        ;;

--- a/scripts/perf-lab/load-tests/load-test-fixed-threads-read-all.hf.yml
+++ b/scripts/perf-lab/load-tests/load-test-fixed-threads-read-all.hf.yml
@@ -1,0 +1,112 @@
+# =============================================================================
+# Hyperfoil Load Test Configuration
+# =============================================================================
+#
+# This configuration file defines a load test scenario for the application's read-all
+# endpoint. It includes a warmup phase followed by a delay, then the main load test phase.
+#
+# All phases target the same HTTP endpoint.
+#
+# This is to replace how we did things exactly as before:
+# warmup
+# wrk -t 2 -c 100 -d 2m --timeout 2m http://localhost:8080/fruits
+#
+# cooldown
+# sleep 30s
+#
+# loadTest
+# wrk -t 2 -c 100 -d 30s --timeout 30s http://localhost:8080/fruits
+#
+# Configurable Parameters:
+# ----------------------------------
+# PROTOCOL               - HTTP protocol to use (default: http)
+#                           Options: http, https
+# HOST                   - Target server hostname (default: localhost)
+# PORT                   - Target server port (default: 8080)
+# CONNECTIONS            - Number of HTTP connections (-c wrk param) (default: 100)
+# HIDE_WARMUP_PHASE      - Hide the warmup phase details (default: false)
+# PATH                   - HTTP endpoint path to test (default: /fruits)
+# WARMUP_DURATION        - Duration of the warmup phase (-d wrk param) (default: 2m)
+# WARMUP_MAX_DURATION    - Maximum duration of the warmup phase (default: 4m)
+# WARMUP_PAUSE_DURATION  - Duration of the pause between warmup and main load test (default: 30s)
+# WARMUP_REQUEST_TIMEOUT - Timeout for warmup requests (--timeout wrk param) (default: 2m)
+# LOAD_REQUEST_TIMEOUT   - Timeout for main load test requests (--timeout wrk param) (default: 30s)
+# LOAD_DURATION          - Duration of the main load test phase (-d wrk param) (default: 30s)
+# LOAD_MAX_DURATION      - Maximum duration of the main load test phase (default: 1m)
+# THREADS                - Number of threads to use (-t wrk param) (default: 2)
+#
+# Usage:
+# ------
+# Override parameters using: -P PARAM_NAME=value
+# Example: jbang run@hyperfoil -PHOST=example.com -PPORT=443 -PPROTOCOL=https load-test-fixed-threads-read-all.hf.yml
+#
+# =============================================================================
+
+name: load-test-fixed-threads-read-all
+threads: !param THREADS 2
+http:
+  - protocol: !param PROTOCOL http
+    host: !param HOST localhost
+    port: !param PORT 8080
+    sharedConnections: !param CONNECTIONS 100
+    allowHttp2: false
+    useHttpCache: false
+ergonomics:
+  repeatCookies: false
+  userAgentFromSession: false
+
+phases:
+  - warmup:
+      always:
+        users: !param CONNECTIONS 100
+        duration: !param WARMUP_DURATION 2m
+        maxDuration: !param WARMUP_MAX_DURATION 4m
+        isWarmup: !param HIDE_WARMUP_PHASE false
+        scenario:
+          maxRequests: 1
+          maxSequences: 1
+          orderedSequences:
+            - getAllFruits:
+                - httpRequest:
+                      GET: !param PATH /fruits
+                      timeout: !param WARMUP_REQUEST_TIMEOUT 2m
+                      headers:
+                        accept: application/json
+
+  - cooldown:
+      noop:
+        startAfter: warmup
+        duration: !param WARMUP_PAUSE_DURATION 30s
+
+  - logStart:
+      atOnce:
+        users: 1
+        startAfterStrict:
+          - warmup
+          - cooldown
+        scenario:
+          maxRequests: 1
+          maxSequences: 1
+          orderedSequences:
+            - log:
+                - timestamp:
+                    toVar: now
+                    pattern: "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+                - log: "loadTest started at ${now}"
+
+  - loadTest:
+      always:
+        users: !param CONNECTIONS 100
+        duration: !param LOAD_DURATION 30s
+        maxDuration: !param LOAD_MAX_DURATION 1m
+        startAfterStrict: logStart
+        scenario:
+          maxRequests: 1
+          maxSequences: 1
+          orderedSequences:
+            - getAllFruits:
+                - httpRequest:
+                      GET: !param PATH /fruits
+                      timeout: !param LOAD_REQUEST_TIMEOUT 30s
+                      headers:
+                        accept: application/json

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -44,7 +44,7 @@ states:
   config.profiler.name: none #jfr syncjfr flamegraph
   config.profiler.events: cpu
 
-  config.repo.branch: main
+  config.repo.branch: ootb
   config.repo.url: https://github.com/quarkusio/spring-quarkus-perf-comparison.git
 
   config.num_iterations: 3

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -224,8 +224,10 @@ scripts:
     - sh: echo $(realpath ~)
     - set-state: RUN.BASE_DIR
     - set-state: RUN.REPO_DIR ${{BASE_DIR}}/spring-quarkus-perf-comparison
+    - set-state: RUN.HYPERFOIL_LOGS_DIR ${{REPO_DIR}}/logs/hyperfoil
     - set-state: RUN.PROJ_REPO_DIR ${{REPO_DIR}}/${{PROJ_REPO_NAME}}
     - set-state: RUN.SCRIPTS_DIR ${{PROJ_REPO_DIR}}/scripts/perf-lab
+    - set-state: RUN.LOAD_TESTS_SCRIPTS_DIR ${{SCRIPTS_DIR}}/load-tests
     - set-state: RUN.HELPER_SCRIPTS_DIR ${{SCRIPTS_DIR}}/scripts
     - set-state: RUN.SPRING3_BOOT_DIR ${{PROJ_REPO_DIR}}/springboot3
     - set-state: RUN.SPRING4_BOOT_DIR ${{PROJ_REPO_DIR}}/springboot4
@@ -240,6 +242,7 @@ scripts:
         "ENV: ${{env}}"
         "BASE_DIR: ${{BASE_DIR}}"
         "REPO_DIR: ${{REPO_DIR}}"
+        "HYPERFOIL_LOGS_DIR: ${{HYPERFOIL_LOGS_DIR}}"
         "SCRIPTS_DIR: ${{SCRIPTS_DIR}}"
         "SPRING3_BOOT_DIR: ${{SPRING3_BOOT_DIR}}"
         "SPRING4_BOOT_DIR: ${{SPRING4_BOOT_DIR}}"
@@ -277,6 +280,7 @@ scripts:
   config-env:
     - sh: rm -Rf ${{REPO_DIR}}/logs
     - sh: mkdir -p ${{REPO_DIR}}/logs
+    - sh: mkdir -p ${{HYPERFOIL_LOGS_DIR}}
 
   clone-repo:
     - sh: rm -Rf ${{REPO_DIR}}
@@ -556,6 +560,7 @@ scripts:
     - log: Running workload
     - sh: cd ${{RUNTIMECMD.dir}}
     - set-state: RUNTIME_NAME ${{RUNTIMECMD.name}}
+    - queue-download: ${{HYPERFOIL_LOGS_DIR}}
     - set-state:
         key: APP_LOG_REGEX
         value: ${{RUNTIMECMD.logFileStartedRegex}}
@@ -563,11 +568,11 @@ scripts:
       then:
         - set-state:
             key: LOG_FILE
-            value: ${{REPO_DIR}}/logs/load-test-${{RUNTIMECMD.name}}-${{ITERATION}}.log
+            value: ${{REPO_DIR}}/logs/load-test-${{RUNTIME_NAME}}-${{ITERATION}}.log
         - sh: touch ${{LOG_FILE}}
-        - queue-download: ${{REPO_DIR}}/logs/wrk-warmup-${{RUNTIMECMD.name}}-${{ITERATION}}.log
+        - sh: mkdir -p ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}}
+        - queue-download: ${{REPO_DIR}}/logs/hf-${{RUNTIME_NAME}}-${{ITERATION}}.log
         - queue-download: ${{LOG_FILE}}
-        - queue-download: ${{REPO_DIR}}/logs/wrk-${{RUNTIMECMD.name}}-${{ITERATION}}.log
         - script: start-test-services
         - script: sync-drop-fs-cache
         - set-signal: LOAD_STEADY_STATE_START 1
@@ -576,8 +581,8 @@ scripts:
           then:
             - regex: "^syncjfr$"
               then:
-                - queue-download: ${{REPO_DIR}}/logs/jfr.${{RUNTIMECMD.name}}-${{ITERATION}}.jfr
-                - sh: echo "${{RUNTIMECMD.runCmd}}" | sed 's#-jar#-XX:StartFlightRecording=filename=${{REPO_DIR}}/logs/jfr.${{RUNTIMECMD.name}}-${{ITERATION}}.jfr,settings=profile,dumponexit=true -jar#'
+                - queue-download: ${{REPO_DIR}}/logs/jfr.${{RUNTIME_NAME}}-${{ITERATION}}.jfr
+                - sh: echo "${{RUNTIMECMD.runCmd}}" | sed 's#-jar#-XX:StartFlightRecording=filename=${{REPO_DIR}}/logs/jfr.${{RUNTIME_NAME}}-${{ITERATION}}.jfr,settings=profile,dumponexit=true -jar#'
                   then:
                     - set-state: SYNCJFR_RUN_CMD
                 - sh: ${{SYNCJFR_RUN_CMD}} &>${{LOG_FILE}} &
@@ -590,7 +595,7 @@ scripts:
           with:
             pid: ${{JVM_PID}}
             log_dir: ${{REPO_DIR}}/logs
-            runtime_name: ${{RUNTIMECMD.name}}
+            runtime_name: ${{RUNTIME_NAME}}
             iteration: ${{ITERATION}}
         - log: JVM_PID = ${{JVM_PID}}
         - read-state: ${{config.profiler.name}}
@@ -601,7 +606,7 @@ scripts:
                 - script: async-profiler-configure
                 - set-state:
                     key: PROFILER_LOGFILE
-                    value: "${{RUNTIMECMD.name}}-${{ITERATION}}.${{= '${{config.profiler.name}}' == 'jfr' ? 'jfr' : 'html' }}"
+                    value: "${{RUNTIME_NAME}}-${{ITERATION}}.${{= '${{config.profiler.name}}' == 'jfr' ? 'jfr' : 'html' }}"
                 - script:
                     name: async-profiler-run
                     async: true
@@ -619,64 +624,117 @@ scripts:
             log_file: ${{LOG_FILE}}
             log_regex: ${{APP_LOG_REGEX}}
         - wait-for: LOG_REGEX_REACHED
-        - sh: ${{RUN.WRK_BIN}} -t 2 -c 100 -d 2m --timeout 2m ${{TARGET_URL}} 2>&1 >${{REPO_DIR}}/logs/wrk-warmup-${{RUNTIMECMD.name}}-${{ITERATION}}.log
-        - regex: unable to connect
-          then:
-            - abort: unable to connect to target application
-        - sleep: 30s # Wait for the app to complete warmup
         - signal: LOAD_STEADY_STATE_START
-        - sh: ${{RUN.WRK_BIN}} -t 2 -c 100 -d 30s --timeout 30s ${{TARGET_URL}} > ${{REPO_DIR}}/logs/wrk-${{RUNTIMECMD.name}}-${{ITERATION}}.log 2>&1 &
-        - sh: WRK_PID=$! && echo $WRK_PID
-        - set-state: WRK_PID
+        - sh: |
+            ${{LOAD_GEN_CMD_PREFIX}} jbang \
+              -Dio.hyperfoil.rootdir=${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}} \
+              -Dio.hyperfoil.cpu.watchdog.idle.threshold=0.0 \
+              -R \
+              -XX:+UseNUMA \
+              run@hyperfoil \
+                -d ${{RUNTIME_NAME}}-${{ITERATION}} \
+                -o ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}} \
+                ${{LOAD_TESTS_SCRIPTS_DIR}}/load-test-fixed-threads-read-all.hf.yml 2>&1 >${{REPO_DIR}}/logs/hf-${{RUNTIME_NAME}}-${{ITERATION}}.log &
+        - sh: HF_PID=$! && echo $HF_PID
+          then:
+            - set-state: HF_PID
         - script:
             name: monitor-process
             async: true
           with:
             name: pidstat
-            command: pidstat -u -w -t -p ${{WRK_PID}} 1
-            log_file: ${{REPO_DIR}}/logs/pidstat-wrk-${{RUNTIME_NAME}}-${{ITERATION}}.log
-        - sh: wait ${{WRK_PID}}
-        - sh: cat ${{REPO_DIR}}/logs/wrk-${{RUNTIMECMD.name}}-${{ITERATION}}.log | grep "Requests/sec" | awk '{print $2}'
+            command: pidstat -u -w -t -p ${{HF_PID}} 1
+            log_file: ${{REPO_DIR}}/logs/pidstat-hf-${{RUNTIME_NAME}}-${{ITERATION}}.log
+        - sh: wait ${{HF_PID}}
+        - sh: cat ${{REPO_DIR}}/logs/hf-${{RUNTIME_NAME}}-${{ITERATION}}.log | grep "Started run" | awk '{print $3}'
           then:
-            - set-state: THROUGHPUT
+            - set-state:
+                key: RUN_NUM
+                autoConvert: false
+        - sh: cat ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}}/run/${{RUN_NUM}}/all.json
+          then:
+            - json: $.stats[?(@.phase == 'loadTest')].total.summary
+              then:
+                - json: $.startTime
+                  then:
+                    - set-state: START_TIME
+                  else:
+                    - abort: Unable to find startTime in ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}}/run/${{RUN_NUM}}/all.json
+                - json: $.endTime
+                  then:
+                    - set-state: END_TIME
+                  else:
+                    - abort: Unable to find endTime in ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}}/run/${{RUN_NUM}}/all.json
+                - json: $.requestCount
+                  then:
+                    - set-state: REQUEST_COUNT
+                  else:
+                    - abort: Unable to find request count in ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}}/run/${{RUN_NUM}}/all.json
+                - json: $.connectionErrors
+                  then:
+                    - set-state: CONNECTION_ERRORS
+                  else:
+                    - set-state: CONNECTION_ERRORS 0
+                - json: $.requestTimeouts
+                  then:
+                    - set-state: REQUEST_TIMEOUTS
+                  else:
+                    - set-state: REQUEST_TIMEOUTS 0
+                - json: $.invalid
+                  then:
+                    - set-state: TOTAL_APP_ERRORS
+                  else:
+                    - set-state: TOTAL_APP_ERRORS 0
+                - json: $.extensions.http.status_4xx
+                  then:
+                    - set-state: APP_4XX_ERRORS
+                  else:
+                    - set-state: APP_4XX_ERRORS 0
+                - json: $.extensions.http.status_5xx
+                  then:
+                    - set-state: APP_5XX_ERRORS
+                  else:
+                    - set-state: APP_5XX_ERRORS 0
+              else:
+                - abort: Unable to find summary in ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}}/run/${{RUN_NUM}}/all.json
+        - set-state:
+            key: THROUGHPUT
+            value: ${{= ${{REQUEST_COUNT}}/((${{END_TIME}}-${{START_TIME}})/1000) }}
         - script: state-array-push
           with:
-            array: RUN.output.results.${{RUNTIMECMD.name}}.load.throughput
+            array: RUN.output.results.${{RUNTIME_NAME}}.load.throughput
             value: ${{THROUGHPUT}}
-        - sh: cat ${{REPO_DIR}}/logs/wrk-${{RUNTIMECMD.name}}-${{ITERATION}}.log | grep "Socket errors:" | sed -E 's/.*connectionErrors ([0-9]+).*/\1/'
-          then:
-            - regex: ^$
-              then:
-                - set-state: CONNECTION_ERRORS 0
-              else:
-                - set-state: CONNECTION_ERRORS
         - script: state-array-push
           with:
-            array: RUN.output.results.${{RUNTIMECMD.name}}.load.connectionErrors
+            array: RUN.output.results.${{RUNTIME_NAME}}.load.connectionErrors
             value: ${{CONNECTION_ERRORS}}
-
-        - sh: cat ${{REPO_DIR}}/logs/wrk-${{RUNTIMECMD.name}}-${{ITERATION}}.log | grep "Socket errors:" | sed -E 's/.*requestTimeouts ([0-9]+)/\1/'
-          then:
-            - regex: ^$
-              then:
-                - set-state: REQUEST_TIMEOUTS 0
-              else:
-                - set-state: REQUEST_TIMEOUTS
         - script: state-array-push
           with:
-            array: RUN.output.results.${{RUNTIMECMD.name}}.load.requestTimeouts
+            array: RUN.output.results.${{RUNTIME_NAME}}.load.requestTimeouts
             value: ${{REQUEST_TIMEOUTS}}
+        - script: state-array-push
+          with:
+            array: RUN.output.results.${{RUNTIME_NAME}}.load.appErrors
+            value: ${{TOTAL_APP_ERRORS}}
+        - script: state-array-push
+          with:
+            array: RUN.output.results.${{RUNTIME_NAME}}.load.app4xxErrors
+            value: ${{APP_4XX_ERRORS}}
+        - script: state-array-push
+          with:
+            array: RUN.output.results.${{RUNTIME_NAME}}.load.app5xxErrors
+            value: ${{APP_5XX_ERRORS}}
 
         - sh: pmap -x $PID | grep total | awk '{print $4}'
           then:
             - set-state: RSS
         - script: state-array-push
           with:
-            array: RUN.output.results.${{RUNTIMECMD.name}}.load.rss
+            array: RUN.output.results.${{RUNTIME_NAME}}.load.rss
             value: ${{= ${{RSS}}/1024 }}
         - script: state-array-push
           with:
-            array: RUN.output.results.${{RUNTIMECMD.name}}.load.throughputDensity
+            array: RUN.output.results.${{RUNTIME_NAME}}.load.throughputDensity
             value: ${{= ${{THROUGHPUT}}/${{RSS}}*1024 }}
         - signal: LOAD_TEST_COMPLETE
         - sh: kill -15 $PID
@@ -685,24 +743,36 @@ scripts:
         - script: stop-test-services
     - script: state-array-calc-avg
       with:
-        var-name: RUN.output.results.${{RUNTIMECMD.name}}.load.avThroughput
-        array: RUN.output.results.${{RUNTIMECMD.name}}.load.throughput
+        var-name: RUN.output.results.${{RUNTIME_NAME}}.load.avThroughput
+        array: RUN.output.results.${{RUNTIME_NAME}}.load.throughput
     - script: state-array-calc-avg
       with:
-        var-name: RUN.output.results.${{RUNTIMECMD.name}}.load.avMaxRss
-        array: RUN.output.results.${{RUNTIMECMD.name}}.load.rss
+        var-name: RUN.output.results.${{RUNTIME_NAME}}.load.avMaxRss
+        array: RUN.output.results.${{RUNTIME_NAME}}.load.rss
     - script: state-array-calc-max
       with:
-        var-name: RUN.output.results.${{RUNTIMECMD.name}}.load.maxThroughputDensity
-        array: RUN.output.results.${{RUNTIMECMD.name}}.load.throughputDensity
+        var-name: RUN.output.results.${{RUNTIME_NAME}}.load.maxThroughputDensity
+        array: RUN.output.results.${{RUNTIME_NAME}}.load.throughputDensity
     - script: state-array-calc-avg
       with:
-        var-name: RUN.output.results.${{RUNTIMECMD.name}}.load.avConnectionErrors
-        array: RUN.output.results.${{RUNTIMECMD.name}}.load.connectionErrors
+        var-name: RUN.output.results.${{RUNTIME_NAME}}.load.avConnectionErrors
+        array: RUN.output.results.${{RUNTIME_NAME}}.load.connectionErrors
     - script: state-array-calc-avg
       with:
-        var-name: RUN.output.results.${{RUNTIMECMD.name}}.load.avRequestTimeouts
-        array: RUN.output.results.${{RUNTIMECMD.name}}.load.requestTimeouts
+        var-name: RUN.output.results.${{RUNTIME_NAME}}.load.avRequestTimeouts
+        array: RUN.output.results.${{RUNTIME_NAME}}.load.requestTimeouts
+    - script: state-array-calc-avg
+      with:
+        var-name: RUN.output.results.${{RUNTIME_NAME}}.load.avAppErrors
+        array: RUN.output.results.${{RUNTIME_NAME}}.load.appErrors
+    - script: state-array-calc-avg
+      with:
+        var-name: RUN.output.results.${{RUNTIME_NAME}}.load.avApp4xxErrors
+        array: RUN.output.results.${{RUNTIME_NAME}}.load.app4xxErrors
+    - script: state-array-calc-avg
+      with:
+        var-name: RUN.output.results.${{RUNTIME_NAME}}.load.avApp5xxErrors
+        array: RUN.output.results.${{RUNTIME_NAME}}.load.app5xxErrors
 
   watch-log:
     - sh: tail -f ${{log_file}}

--- a/scripts/perf-lab/run-benchmarks.sh
+++ b/scripts/perf-lab/run-benchmarks.sh
@@ -315,7 +315,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   RUN_IDENTIFIER=""
   SCM_REPO_URL="https://github.com/quarkusio/spring-quarkus-perf-comparison.git"
   SCM_REPO_BRANCH="ootb"
-  SCENARIO="tuned"
+  SCENARIO="ootb"
   SCENARIO_SET_BY_USER=""
   GRAALVM_HOME=""
   GRAALVM_VERSION="25.0.2-graalce"

--- a/scripts/perf-lab/run-benchmarks.sh
+++ b/scripts/perf-lab/run-benchmarks.sh
@@ -314,7 +314,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   DESCRIPTION=""
   RUN_IDENTIFIER=""
   SCM_REPO_URL="https://github.com/quarkusio/spring-quarkus-perf-comparison.git"
-  SCM_REPO_BRANCH="main"
+  SCM_REPO_BRANCH="ootb"
   SCENARIO="tuned"
   SCENARIO_SET_BY_USER=""
   GRAALVM_HOME=""

--- a/scripts/stress.sh
+++ b/scripts/stress.sh
@@ -57,12 +57,25 @@ done
 TTFR=$((($(_date) - ts)/1000000))
 RSS=`ps -o rss= -p $CURRENT_PID | sed 's/^ *//g'`
 
+tempdir=$(mktemp -d)
+
+jbang \
+  -Dio.hyperfoil.rootdir=${tempdir} \
+  -Dio.hyperfoil.cpu.watchdog.idle.threshold=0.0 \
+  run@hyperfoil \
+    -o ${tempdir} \
+    -PLOAD_DURATION=20s \
+    -PWARMUP_DURATION=0s \
+    -PWARMUP_PAUSE_DURATION=0s \
+    ${thisdir}/perf-lab/load-tests/load-test-fixed-threads-read-all.hf.yml &> ${tempdir}/hf.log
+
+kill $(lsof -t -i:8080) &>/dev/null
+${thisdir}/infra.sh -d
+
 echo "-------------------------------------------------"
 printf "Time to first request: %.3f sec\n" $(echo "$TTFR / 1000" | bc -l)
 printf "RSS (after 1st request): %.1f MB\n" $(echo "$RSS / 1024" | bc -l)
 echo "-------------------------------------------------"
 
-jbang wrk@hyperfoil -t2 -c100 -d20s --timeout 1s --latency http://localhost:8080/fruits
-
-${thisdir}/infra.sh -d
-kill $(lsof -t -i:8080) &>/dev/null
+cat ${tempdir}/hf.log
+echo "Other information output by hyperfoil is available in ${tempdir}"


### PR DESCRIPTION
## Summary
- Syncs PR #113 from `main` to `ootb`
- Replaces wrk-based load testing with Hyperfoil YAML configuration in perf-lab scripts and `stress.sh`
- Adds new `load-test-fixed-threads-read-all.hf.yml` Hyperfoil config file with configurable warmup, cooldown, and load test phases
- Parses Hyperfoil JSON output for throughput, connection errors, request timeouts, and HTTP 4xx/5xx error tracking
- Preserves all ootb-specific configuration (no OTEL monitoring, no `buildRequiresTestServices` changes)

Fixes #42