### PR TITLE
Add exit code failsafe to start-test-services in qDup

### DIFF
--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -356,6 +356,11 @@ scripts:
         - regex: "Error: Otel LGTM failed to become ready"
           then:
             - abort: Otel LGTM failed to become ready
+    - sh: echo $?
+      then:
+        - regex: "^0$"
+          else:
+            - abort: start-test-services (infra.sh) failed with a non-zero exit code
 
   capture-otel-data:
     - sh: ${{PROJ_REPO_DIR}}/scripts/lookup_otel_service.sh > ${{REPO_DIR}}/logs/otel-${{RUNTIMECMD.name}}-${{ITERATION}}.log 2>&1


### PR DESCRIPTION
## Summary
- Adds an exit code check after the `infra.sh` command in the `start-test-services` qDup script
- If `infra.sh` exits with a non-zero code for any reason (not just the two currently watched error messages), the qDup run now aborts with a descriptive message
- All 4 call sites (`measure-build-times`, `measure-time-to-first-request`, `measure-rss`, `run-load-test`) inherit the fix automatically

## Test plan
- [ ] Verify YAML indentation is correct and qDup parses the script without errors
- [ ] Temporarily inject a failure into `infra.sh` (e.g., `exit 1` early) and confirm the qDup abort triggers with the message "start-test-services (infra.sh) failed with a non-zero exit code"
- [ ] Verify normal successful runs still pass through without aborting