### PR TITLE
[OOTB] Add exit code failsafe to start-test-services in qDup

### DIFF
--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -352,6 +352,11 @@ scripts:
         - regex: "Error: PostgreSQL failed to become ready"
           then:
             - abort: PostgreSQL failed to become ready
+    - sh: echo $?
+      then:
+        - regex: "^0$"
+          else:
+            - abort: start-test-services (infra.sh) failed with a non-zero exit code
 
   capture-otel-data:
     - sh: ${{PROJ_REPO_DIR}}/scripts/lookup_otel_service.sh > ${{REPO_DIR}}/logs/otel-${{RUNTIMECMD.name}}-${{ITERATION}}.log 2>&1


### PR DESCRIPTION
ootb variant of #524 

## Summary
- Adds an exit code check after the `infra.sh` command in the `start-test-services` qDup script
- If `infra.sh` exits with a non-zero code for any reason (not just the currently watched PostgreSQL error message), the qDup run now aborts with a descriptive message
- All 4 call sites (`measure-build-times`, `measure-time-to-first-request`, `measure-rss`, `run-load-test`) inherit the fix automatically

## Test plan
- [ ] Verify YAML indentation is correct and qDup parses the script without errors
- [ ] Temporarily inject a failure into `infra.sh` (e.g., `exit 1` early) and confirm the qDup abort triggers with the message "start-test-services (infra.sh) failed with a non-zero exit code"
- [ ] Verify normal successful runs still pass through without aborting