### PR TITLE
Reduce hyperfoil output

### DIFF
--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -660,52 +660,50 @@ scripts:
             - set-state:
                 key: RUN_NUM
                 autoConvert: false
-        - sh: cat ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}}/run/${{RUN_NUM}}/all.json
+        - sh: jq '.stats[] | select(.phase == "loadTest") | .total.summary' ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}}/run/${{RUN_NUM}}/all.json
           then:
-            - json: $.stats[?(@.phase == 'loadTest')].total.summary
+            - json: $.startTime
               then:
-                - json: $.startTime
-                  then:
-                    - set-state: START_TIME
-                  else:
-                    - abort: Unable to find startTime in ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}}/run/${{RUN_NUM}}/all.json
-                - json: $.endTime
-                  then:
-                    - set-state: END_TIME
-                  else:
-                    - abort: Unable to find endTime in ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}}/run/${{RUN_NUM}}/all.json
-                - json: $.requestCount
-                  then:
-                    - set-state: REQUEST_COUNT
-                  else:
-                    - abort: Unable to find request count in ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}}/run/${{RUN_NUM}}/all.json
-                - json: $.connectionErrors
-                  then:
-                    - set-state: CONNECTION_ERRORS
-                  else:
-                    - set-state: CONNECTION_ERRORS 0
-                - json: $.requestTimeouts
-                  then:
-                    - set-state: REQUEST_TIMEOUTS
-                  else:
-                    - set-state: REQUEST_TIMEOUTS 0
-                - json: $.invalid
-                  then:
-                    - set-state: TOTAL_APP_ERRORS
-                  else:
-                    - set-state: TOTAL_APP_ERRORS 0
-                - json: $.extensions.http.status_4xx
-                  then:
-                    - set-state: APP_4XX_ERRORS
-                  else:
-                    - set-state: APP_4XX_ERRORS 0
-                - json: $.extensions.http.status_5xx
-                  then:
-                    - set-state: APP_5XX_ERRORS
-                  else:
-                    - set-state: APP_5XX_ERRORS 0
+                - set-state: START_TIME
               else:
-                - abort: Unable to find summary in ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}}/run/${{RUN_NUM}}/all.json
+                - abort: Unable to find startTime in ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}}/run/${{RUN_NUM}}/all.json
+            - json: $.endTime
+              then:
+                - set-state: END_TIME
+              else:
+                - abort: Unable to find endTime in ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}}/run/${{RUN_NUM}}/all.json
+            - json: $.requestCount
+              then:
+                - set-state: REQUEST_COUNT
+              else:
+                - abort: Unable to find request count in ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}}/run/${{RUN_NUM}}/all.json
+            - json: $.connectionErrors
+              then:
+                - set-state: CONNECTION_ERRORS
+              else:
+                - set-state: CONNECTION_ERRORS 0
+            - json: $.requestTimeouts
+              then:
+                - set-state: REQUEST_TIMEOUTS
+              else:
+                - set-state: REQUEST_TIMEOUTS 0
+            - json: $.invalid
+              then:
+                - set-state: TOTAL_APP_ERRORS
+              else:
+                - set-state: TOTAL_APP_ERRORS 0
+            - json: $.extensions.http.status_4xx
+              then:
+                - set-state: APP_4XX_ERRORS
+              else:
+                - set-state: APP_4XX_ERRORS 0
+            - json: $.extensions.http.status_5xx
+              then:
+                - set-state: APP_5XX_ERRORS
+              else:
+                - set-state: APP_5XX_ERRORS 0
+          else:
+            - abort: Unable to find summary in ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}}/run/${{RUN_NUM}}/all.json
         - set-state:
             key: THROUGHPUT
             value: ${{= ${{REQUEST_COUNT}}/((${{END_TIME}}-${{START_TIME}})/1000) }}

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -702,8 +702,6 @@ scripts:
                 - set-state: APP_5XX_ERRORS
               else:
                 - set-state: APP_5XX_ERRORS 0
-          else:
-            - abort: Unable to find summary in ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}}/run/${{RUN_NUM}}/all.json
         - set-state:
             key: THROUGHPUT
             value: ${{= ${{REQUEST_COUNT}}/((${{END_TIME}}-${{START_TIME}})/1000) }}


### PR DESCRIPTION
Fixes #532 

I tested this locally:

```
12:20:49,511 [ test-runner:run-tests-1287 @ target-host ] jq '.stats[] | select(.phase == "loadTest") | .total.summary' /home/hyperfoil/spring-quarkus-perf-comparison/logs/hyperfoil/quarkus3-jvm-0/run/0000/all.json                                     
{                                                                                                                                                                                                                                                          
  "startTime": 1777998017184,                                                                                                                                                                                                                              
  "endTime": 1777998047192,                                                                                                                                                                                                                                
  "minResponseTime": 143360,                                                                                                                                                                                                                               
  "meanResponseTime": 5539367,                                                                                                                                                                                                                             
  "stdDevResponseTime": 6004342,                                                                                                                                                                                                                           
  "maxResponseTime": 156237823,                                                                                                                                                                                                                            
  "percentileResponseTime": {                                                                                                                                                                                                                              
    "50.0": 3948543,                                                                                                                                                                                                                                       
    "90.0": 10878975,                                                                                                                                                                                                                                      
    "99.0": 30408703,                                                                                                                                                                                                                                      
    "99.9": 65273855,                                                                                                                                                                                                                                      
    "99.99": 93323263                                                                                                                                                                                                                                      
  },                                                                                                                                                                                                                                                       
  "requestCount": 541430,                                                                                                                                                                                                                                  
  "responseCount": 541430,                                                                                                                                                                                                                                 
  "invalid": 0,                                                                                                                                                                                                                                            
  "connectionErrors": 0,                                                                                                                                                                                                                                   
  "requestTimeouts": 0,                                                                                                                                                                                                                                    
  "internalErrors": 0,                                                                                                                                                                                                                                     
  "blockedTime": 0,                                                                                                                                                                                                                                        
  "extensions": {                                                                                                                                                                                                                                          
    "http": {                                                                                                                                                                                                                                              
      "@type": "http",                                                                                                                                                                                                                                     
      "status_2xx": 541430,                                                                                                                                                                                                                                
      "status_3xx": 0,                                                                                                                                                                                                                                     
      "status_4xx": 0,                                                                                                                                                                                                                                     
      "status_5xx": 0,                                                                                                                                                                                                                                     
      "status_other": 0,                                                                                                                                                                                                                                   
      "cacheHits": 0                                                                                                                                                                                                                                       
    }                                                                                                                                                                                                                                                      
  }                                                                                                                                                                                                                                                        
}                                                                                                                                                                                                                                                          
12:20:49,513 [ test-runner:run-tests-1287 @ target-host ] json: $.startTime                                                                                                                                                                                
1777998017184                                                                                                                                                                                                                                              
12:20:49,514 [ test-runner:run-tests-1287 @ target-host ] set-state: START_TIME 1777998017184                                                                                                                                                              
12:20:49,514 [ test-runner:run-tests-1287 @ target-host ] json: $.endTime                                                                                                                                                                                  
1777998047192                                                                                                                                                                                                                                              
12:20:49,514 [ test-runner:run-tests-1287 @ target-host ] set-state: END_TIME 1777998047192                                                                                                                                                                
12:20:49,515 [ test-runner:run-tests-1287 @ target-host ] json: $.requestCount                                                                                                                                                                             
541430                                                                                                                                                                                                                                                     
12:20:49,515 [ test-runner:run-tests-1287 @ target-host ] set-state: REQUEST_COUNT 541430                                                                                                                                                                  
12:20:49,516 [ test-runner:run-tests-1287 @ target-host ] json: $.connectionErrors                                                                                                                                                                         
0                                                                                                                                                                                                                                                          
12:20:49,516 [ test-runner:run-tests-1287 @ target-host ] set-state: CONNECTION_ERRORS 0                                                                                                                                                                   
12:20:49,517 [ test-runner:run-tests-1287 @ target-host ] json: $.requestTimeouts                                                                                                                                                                          
12:20:49,517 [ test-runner:run-tests-1287 @ target-host ] set-state: REQUEST_TIMEOUTS 0                                                                                                                                                                    
12:20:49,517 [ test-runner:run-tests-1287 @ target-host ] json: $.invalid                                                                                                                                                                                  
12:20:49,518 [ test-runner:run-tests-1287 @ target-host ] set-state: TOTAL_APP_ERRORS 0                                                                                                                                                                    
12:20:49,518 [ test-runner:run-tests-1287 @ target-host ] json: $.extensions.http.status_4xx                                                                                                                                                               
12:20:49,518 [ test-runner:run-tests-1287 @ target-host ] set-state: APP_4XX_ERRORS 0                                                                                                                                                                      
12:20:49,519 [ test-runner:run-tests-1287 @ target-host ] json: $.extensions.http.status_5xx                                                                                                                                                               
12:20:49,519 [ test-runner:run-tests-1287 @ target-host ] set-state: APP_5XX_ERRORS 0                                                                                                                                                                      
12:20:49,566 [ test-runner:run-tests-1287 @ target-host ] set-state: THROUGHPUT 18042.85523860304                                                                                                                                                          
12:20:49,566 [ test-runner:run-tests-1287 @ target-host ] script-cmd: state-array-push                                                                                                                                                                     
12:20:49,566 [ test-runner:run-tests-1287 @ target-host ] state-array-push                                                                                                                                                                                 
12:20:49,637 [ test-runner:run-tests-1287 @ target-host ] set-state: RUN.output.results.quarkus3-jvm.load.throughput [18042.85523860304]                                                                                                                   
12:20:49,638 [ test-runner:run-tests-1287 @ target-host ] script-cmd: state-array-push                                                                                                                                                                     
12:20:49,638 [ test-runner:run-tests-1287 @ target-host ] state-array-push                                                                                                                                                                                 
12:20:49,703 [ test-runner:run-tests-1287 @ target-host ] set-state: RUN.output.results.quarkus3-jvm.load.connectionErrors [0]                                                                                                                             
12:20:49,704 [ test-runner:run-tests-1287 @ target-host ] script-cmd: state-array-push                                                                                                                                                                     
12:20:49,704 [ test-runner:run-tests-1287 @ target-host ] state-array-push                                                                                                                                                                                 
12:20:49,765 [ test-runner:run-tests-1287 @ target-host ] set-state: RUN.output.results.quarkus3-jvm.load.requestTimeouts [0]                                                                                                                              
12:20:49,765 [ test-runner:run-tests-1287 @ target-host ] script-cmd: state-array-push                                                                                                                                                                     
12:20:49,765 [ test-runner:run-tests-1287 @ target-host ] state-array-push                                                                                                                                                                                 
12:20:49,827 [ test-runner:run-tests-1287 @ target-host ] set-state: RUN.output.results.quarkus3-jvm.load.appErrors [0]                                                                                                                                    
12:20:49,827 [ test-runner:run-tests-1287 @ target-host ] script-cmd: state-array-push                                                                                                                                                                     
12:20:49,828 [ test-runner:run-tests-1287 @ target-host ] state-array-push                                                                                                                                                                                 
12:20:49,899 [ test-runner:run-tests-1287 @ target-host ] set-state: RUN.output.results.quarkus3-jvm.load.app4xxErrors [0]                                                                                                                                 
12:20:49,900 [ test-runner:run-tests-1287 @ target-host ] script-cmd: state-array-push                                                                                                                                                                     
12:20:49,900 [ test-runner:run-tests-1287 @ target-host ] state-array-push                                                                                                                                                                                 
12:20:49,965 [ test-runner:run-tests-1287 @ target-host ] set-state: RUN.output.results.quarkus3-jvm.load.app5xxErrors [0]                                                                                                                                 
12:20:50,399 [ test-runner:run-tests-1287 @ target-host ] pmap -x $PID | grep total | awk '{print $4}'                                                                                                                                                     
638016                                                                                                                                                                                                                                                     
12:20:50,401 [ test-runner:run-tests-1287 @ target-host ] set-state: RSS 638016                                                                                                                                                                            
12:20:50,436 [ test-runner:run-tests-1287 @ target-host ] script-cmd: state-array-push                                                                                                                                                                     
12:20:50,436 [ test-runner:run-tests-1287 @ target-host ] state-array-push                                                                                                                                                                                 
12:20:50,509 [ test-runner:run-tests-1287 @ target-host ] set-state: RUN.output.results.quarkus3-jvm.load.rss [623.0625]                                                                                                                                   
12:20:50,524 [ test-runner:run-tests-1287 @ target-host ] script-cmd: state-array-push                                                                                                                                                                     
12:20:50,524 [ test-runner:run-tests-1287 @ target-host ] state-array-push                                                                                                                                                                                 
12:20:50,583 [ test-runner:run-tests-1287 @ target-host ] set-state: RUN.output.results.quarkus3-jvm.load.throughputDensity [28.958339233388365]    
```