### PR TITLE
Fix stderr redirect order for Hyperfoil jbang command

### DIFF
--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -643,7 +643,7 @@ scripts:
               run@hyperfoil \
                 -d ${{RUNTIME_NAME}}-${{ITERATION}} \
                 -o ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}} \
-                ${{LOAD_TESTS_SCRIPTS_DIR}}/load-test-fixed-threads-read-all.hf.yml 2>&1 >${{REPO_DIR}}/logs/hf-${{RUNTIME_NAME}}-${{ITERATION}}.log &
+                ${{LOAD_TESTS_SCRIPTS_DIR}}/load-test-fixed-threads-read-all.hf.yml &>${{REPO_DIR}}/logs/hf-${{RUNTIME_NAME}}-${{ITERATION}}.log &
         - sh: HF_PID=$! && echo $HF_PID
           then:
             - set-state: HF_PID


### PR DESCRIPTION
The Hyperfoil jbang command used `2>&1 >file &` which redirects stderr to the terminal and only stdout to the file. On JDK 25, jbang emits Netty sun.misc.Unsafe deprecation warnings to stderr, which pollute qDup's SSH session and break its shell prompt detection, causing the harness to hang indefinitely.

Changed to `&>file &` to redirect both stdout and stderr to the log file, matching the pattern used by the wrk load test command.

Fixes #537

TLDR:
The wrk load test command used `>file 2>&1 &` (correct redirect order — both stdout and stderr go to the file). The Hyperfoil change (a6e403e) replaced it with `2>&1 >file &` (wrong order — stderr goes to the terminal, only stdout goes to the file). On JDK 25, jbang emits Netty `sun.misc.Unsafe` deprecation warnings to stderr, which leak into qDup's SSH session and break its shell prompt detection, causing the harness to hang.
