### PR TITLE
Tuning label fix: maintain one comment, and skip execution 

### DIFF
--- a/.github/workflows/syncbot.yml
+++ b/.github/workflows/syncbot.yml
@@ -28,21 +28,31 @@ jobs:
           echo "Target branch for sync: $(cat $GITHUB_OUTPUT | grep branch | cut -d= -f2)"
 
       - name: Check for tuning label and exit early if present
+        id: check-tuning
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           LABELS=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
           if echo "$LABELS" | grep -q "^tuning$"; then
             echo "PR has 'tuning' label - sync will be skipped"
-            
-            # Add comment explaining why sync is skipped
-            gh pr comment ${{ github.event.pull_request.number }} --body "🤖 This PR has the \`tuning\` label and will not be automatically synchronized to the \`${{ steps.target-branch.outputs.branch }}\` branch. Tuning probably doesn't make sense for that branch. 🔄"
-            
-            exit 0
+            echo "has_tuning_label=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_tuning_label=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Update PR comment for tuning label
+        if: steps.check-tuning.outputs.has_tuning_label == 'true'
+        uses: quarkusio/action-helpers@main
+        with:
+          action: maintain-one-comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            🤖 This PR has the `tuning` label and will not be automatically synchronized to the `${{ steps.target-branch.outputs.branch }}` branch. Tuning probably doesn't make sense for that branch. 🔄
+          pr-number: ${{ github.event.pull_request.number }}
 
       - name: Cherry-pick commits to target branch
         id: cherry-pick
+        if: steps.check-tuning.outputs.has_tuning_label != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -161,7 +171,7 @@ jobs:
           fi
 
       - name: Update PR comment on success
-        if: steps.push-and-pr.outputs.push_failed_workflows != 'true' && steps.cherry-pick.outputs.skipped_commits == ''
+        if: steps.cherry-pick.outputs.target_branch != '' && steps.push-and-pr.outputs.push_failed_workflows != 'true' && steps.cherry-pick.outputs.skipped_commits == ''
         uses: quarkusio/action-helpers@main
         with:
           action: maintain-one-comment
@@ -171,7 +181,7 @@ jobs:
           pr-number: ${{ github.event.pull_request.number }}
 
       - name: Update PR comment on partial sync
-        if: steps.cherry-pick.outputs.all_skipped != 'true' && steps.cherry-pick.outputs.skipped_commits != ''
+        if: steps.cherry-pick.outputs.target_branch != '' && steps.cherry-pick.outputs.all_skipped != 'true' && steps.cherry-pick.outputs.skipped_commits != ''
         uses: quarkusio/action-helpers@main
         with:
           action: maintain-one-comment
@@ -181,7 +191,7 @@ jobs:
           pr-number: ${{ github.event.pull_request.number }}
 
       - name: Update PR comment when all commits conflict
-        if: steps.cherry-pick.outputs.all_skipped == 'true'
+        if: steps.cherry-pick.outputs.target_branch != '' && steps.cherry-pick.outputs.all_skipped == 'true'
         uses: quarkusio/action-helpers@main
         with:
           action: maintain-one-comment
@@ -191,7 +201,7 @@ jobs:
           pr-number: ${{ github.event.pull_request.number }}
 
       - name: Update PR comment on workflow push failure
-        if: steps.push-and-pr.outputs.push_failed_workflows == 'true'
+        if: steps.cherry-pick.outputs.target_branch != '' && steps.push-and-pr.outputs.push_failed_workflows == 'true'
         uses: quarkusio/action-helpers@main
         with:
           action: maintain-one-comment


### PR DESCRIPTION
See https://github.com/quarkusio/spring-quarkus-perf-comparison/pull/529#issuecomment-4396880485

I've used maintain-one-comment (which I clearly should have done the first time, but somehow I thought it wouldn't be needed), and I've updated the later jobs to not run if the cherry pick step wasn't attempted.