### PR TITLE
Add script and workflow for full-parity spring compatibility

### DIFF
--- a/.github/workflows/test-spring-conversion.yml
+++ b/.github/workflows/test-spring-conversion.yml
@@ -1,0 +1,73 @@
+name: Test Spring Conversion
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/spring-conversion.sh'
+      - 'spring-conversion.md'
+      - 'springboot3/**'
+      - 'quarkus3-spring-compatibility/**'
+      - '.github/workflows/test-spring-conversion.yml'
+  pull_request:
+    paths:
+      - 'scripts/spring-conversion.sh'
+      - 'spring-conversion.md'
+      - 'springboot3/**'
+      - 'quarkus3-spring-compatibility/**'
+      - '.github/workflows/test-spring-conversion.yml'
+  workflow_dispatch:
+
+jobs:
+  test-conversion-default:
+    name: Test conversion (default output)
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Run spring-conversion.sh script (default output)
+        run: |
+          chmod +x scripts/spring-conversion.sh
+          ./scripts/spring-conversion.sh
+
+      - name: Verify build with mvn install
+        run: |
+          cd quarkus3-spring-compatibility
+          ./mvnw install
+          echo "✅ Maven install completed successfully!"
+
+  test-conversion-springboot3:
+    name: Test conversion (in place output)
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Run spring-conversion.sh script (springboot3 output)
+        run: |
+          chmod +x scripts/spring-conversion.sh
+          ./scripts/spring-conversion.sh springboot3
+
+      - name: Verify build with mvn install
+        run: |
+          cd springboot3
+          ./mvnw install
+          echo "✅ Maven install completed successfully!"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This project contains the following modules:
 - [quarkus3-virtual](quarkus3-virtual)
     - A Quarkus 3.x version of the application using Virtual Threads
 - [quarkus3-spring-compatibility](quarkus3-spring-compatibility)
-    - A Quarkus 3.x version of the application using the Spring compatibility layer. You can also recreate this application from the spring application using [a few manual steps](spring-conversion.md).
+    - A Quarkus 3.x version of the application using the Spring compatibility layer. You can also recreate this application from the spring application using [a few manual steps](spring-conversion.md) or by running the automated [`spring-conversion.sh`](scripts/spring-conversion.sh) script.
  
 ## Architecture & Workflow
 

--- a/scripts/spring-conversion.sh
+++ b/scripts/spring-conversion.sh
@@ -98,6 +98,20 @@ rm -rf "${OUTPUT_DIR}/src/main/java/org/acme/config"
 echo -e "${GREEN}✓ Deleted Spring-only config classes${NC}"
 echo ""
 
+echo -e "${YELLOW}Step 8: Replacing Spring @Transactional with Jakarta @Transactional...${NC}"
+# Quarkus doesn't support org.springframework.transaction.annotation.Transactional
+# (see https://github.com/quarkusio/quarkus/issues/54089).
+# Replace with jakarta.transaction.Transactional, which preserves the runtime behaviour.
+# The readOnly hint has no Jakarta equivalent but doesn't affect correctness.
+find "${OUTPUT_DIR}/src/main/java" -name "*.java" -exec sed -i.bak \
+  -e 's/import static org\.springframework\.transaction\.annotation\.Propagation\.SUPPORTS;/import static jakarta.transaction.Transactional.TxType.SUPPORTS;/' \
+  -e 's/import org\.springframework\.transaction\.annotation\.Transactional;/import jakarta.transaction.Transactional;/' \
+  -e 's/@Transactional(propagation = SUPPORTS, readOnly = true)/@Transactional(SUPPORTS)/' \
+  {} +
+find "${OUTPUT_DIR}/src/main/java" -name "*.java.bak" -delete
+echo -e "${GREEN}✓ Replaced Spring @Transactional with Jakarta @Transactional${NC}"
+echo ""
+
 echo -e "${GREEN}=== Dev Mode Conversion Complete ===${NC}"
 echo ""
 echo -e "${YELLOW}To test in dev mode, run:${NC}"
@@ -105,12 +119,12 @@ echo "  cd ${OUTPUT_DIR} && quarkus dev"
 echo ""
 
 # Section 2: Prod Mode Configuration
-echo -e "${YELLOW}Step 8: Copying Quarkus config for prod mode...${NC}"
+echo -e "${YELLOW}Step 9: Copying Quarkus config for prod mode...${NC}"
 cp ./quarkus3/src/main/resources/application.yml "${OUTPUT_DIR}/src/main/resources/application.yml"
 echo -e "${GREEN}✓ Copied application.yml${NC}"
 echo ""
 
-echo -e "${YELLOW}Step 9: Building the application...${NC}"
+echo -e "${YELLOW}Step 10: Building the application...${NC}"
 (cd "${OUTPUT_DIR}" && ./mvnw clean package)
 echo -e "${GREEN}✓ Build complete${NC}"
 echo ""

--- a/scripts/spring-conversion.sh
+++ b/scripts/spring-conversion.sh
@@ -88,6 +88,16 @@ find "${OUTPUT_DIR}/src/main/java" -name "*Application.java" -type f -delete
 echo -e "${GREEN}✓ Deleted SpringBootApplication class${NC}"
 echo ""
 
+echo -e "${YELLOW}Step 7: Deleting Spring-only config classes...${NC}"
+# The config/ package contains L2CacheConfiguration, GraalVMConfig, and L2CacheRuntimeHints.
+# These wire up Caffeine as a JCache provider for Hibernate L2 cache and register
+# GraalVM native-image reflection hints — all Spring-specific plumbing.
+# Quarkus handles Hibernate L2 cache automatically, so these classes are not needed
+# (and won't compile, since the Quarkus pom doesn't include the Caffeine/JCache dependencies).
+rm -rf "${OUTPUT_DIR}/src/main/java/org/acme/config"
+echo -e "${GREEN}✓ Deleted Spring-only config classes${NC}"
+echo ""
+
 echo -e "${GREEN}=== Dev Mode Conversion Complete ===${NC}"
 echo ""
 echo -e "${YELLOW}To test in dev mode, run:${NC}"
@@ -95,12 +105,12 @@ echo "  cd ${OUTPUT_DIR} && quarkus dev"
 echo ""
 
 # Section 2: Prod Mode Configuration
-echo -e "${YELLOW}Step 7: Copying Quarkus config for prod mode...${NC}"
+echo -e "${YELLOW}Step 8: Copying Quarkus config for prod mode...${NC}"
 cp ./quarkus3/src/main/resources/application.yml "${OUTPUT_DIR}/src/main/resources/application.yml"
 echo -e "${GREEN}✓ Copied application.yml${NC}"
 echo ""
 
-echo -e "${YELLOW}Step 8: Building the application...${NC}"
+echo -e "${YELLOW}Step 9: Building the application...${NC}"
 (cd "${OUTPUT_DIR}" && ./mvnw clean package)
 echo -e "${GREEN}✓ Build complete${NC}"
 echo ""

--- a/scripts/spring-conversion.sh
+++ b/scripts/spring-conversion.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# Script to convert Spring Boot application to Quarkus with Spring compatibility libraries
+# Based on steps from spring-conversion.md
+#
+# Usage: ./spring-conversion.sh [output-directory]
+#   output-directory: Target directory for the converted application (default: quarkus3-spring-compatibility, but you can use springboot3 to convert in place and see the diff)
+
+set -e  # Exit on error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Parse arguments
+OUTPUT_DIR="${1:-quarkus3-spring-compatibility}"
+
+echo -e "${GREEN}=== Spring to Quarkus Conversion Script ===${NC}"
+echo -e "${YELLOW}Output directory: ${OUTPUT_DIR}${NC}"
+echo ""
+
+# Check if we're in the right directory
+if [ ! -f "spring-conversion.md" ]; then
+    echo -e "${RED}Error: Must be run from the project root directory${NC}"
+    exit 1
+fi
+
+# Check if source directory exists
+if [ ! -d "springboot3" ]; then
+    echo -e "${RED}Error: springboot3 directory not found${NC}"
+    exit 1
+fi
+
+# Determine source pom location based on output directory
+if [ "$OUTPUT_DIR" = "springboot3" ]; then
+    # If converting in place, we need to preserve the original Spring pom first
+    if [ ! -f "springboot3/pom.xml.spring-original" ]; then
+        echo -e "${YELLOW}Preserving original Spring pom.xml...${NC}"
+        cp springboot3/pom.xml springboot3/pom.xml.spring-original
+        echo -e "${GREEN}✓ Saved original pom.xml${NC}"
+        echo ""
+    fi
+    SOURCE_POM="quarkus3-spring-compatibility/pom.xml"
+else
+    SOURCE_POM="${OUTPUT_DIR}/pom.xml"
+fi
+
+# Check if source pom exists
+if [ ! -f "$SOURCE_POM" ]; then
+    echo -e "${RED}Error: Source pom.xml not found at ${SOURCE_POM}${NC}"
+    exit 1
+fi
+
+# Section 1: Dev Mode Conversion
+echo -e "${YELLOW}Step 1: Saving the Quarkus Spring compatibility pom.xml...${NC}"
+mkdir -p target
+cp "$SOURCE_POM" target/spring-pom.xml
+echo -e "${GREEN}✓ Saved pom.xml${NC}"
+echo ""
+
+if [ "$OUTPUT_DIR" != "springboot3" ]; then
+    echo -e "${YELLOW}Step 2: Deleting the compatibility project...${NC}"
+    rm -rf "$OUTPUT_DIR"
+    echo -e "${GREEN}✓ Deleted ${OUTPUT_DIR}${NC}"
+    echo ""
+
+    echo -e "${YELLOW}Step 3: Copying springboot3 to ${OUTPUT_DIR}...${NC}"
+    cp -r springboot3 "$OUTPUT_DIR"
+    echo -e "${GREEN}✓ Copied springboot3 to ${OUTPUT_DIR}${NC}"
+    echo ""
+fi
+
+echo -e "${YELLOW}Step 4: Replacing the Spring pom with Quarkus Spring compatibility pom...${NC}"
+mv target/spring-pom.xml "${OUTPUT_DIR}/pom.xml"
+echo -e "${GREEN}✓ Replaced ${OUTPUT_DIR}/pom.xml${NC}"
+echo ""
+
+echo -e "${YELLOW}Step 5: Deleting tests (hard to convert for now)...${NC}"
+rm -rf "${OUTPUT_DIR}/src/test"
+echo -e "${GREEN}✓ Deleted tests${NC}"
+echo ""
+
+echo -e "${YELLOW}Step 6: Deleting SpringBootApplication class (not needed with Quarkus)...${NC}"
+# Find and delete the SpringBootApplication file
+find "${OUTPUT_DIR}/src/main/java" -name "*Application.java" -type f -delete
+echo -e "${GREEN}✓ Deleted SpringBootApplication class${NC}"
+echo ""
+
+echo -e "${GREEN}=== Dev Mode Conversion Complete ===${NC}"
+echo ""
+echo -e "${YELLOW}To test in dev mode, run:${NC}"
+echo "  cd ${OUTPUT_DIR} && quarkus dev"
+echo ""
+
+# Section 2: Prod Mode Configuration
+echo -e "${YELLOW}Step 7: Copying Quarkus config for prod mode...${NC}"
+cp ./quarkus3/src/main/resources/application.yml "${OUTPUT_DIR}/src/main/resources/application.yml"
+echo -e "${GREEN}✓ Copied application.yml${NC}"
+echo ""
+
+echo -e "${YELLOW}Step 8: Building the application...${NC}"
+(cd "${OUTPUT_DIR}" && ./mvnw clean package)
+echo -e "${GREEN}✓ Build complete${NC}"
+echo ""
+
+echo -e "${GREEN}=== Conversion Complete ===${NC}"
+echo ""
+echo -e "${YELLOW}To run stress tests:${NC}"
+echo "  ./scripts/stress.sh ${OUTPUT_DIR}/target/quarkus-app/quarkus-run.jar"
+echo ""
+echo -e "${GREEN}Expected result: Throughput should be almost identical to the 'normal' Quarkus app,${NC}"
+echo -e "${GREEN}and more than double that of the Quarkus-free Spring app.${NC}"

--- a/scripts/spring-conversion.sh
+++ b/scripts/spring-conversion.sh
@@ -129,6 +129,12 @@ echo -e "${YELLOW}Step 10: Building the application...${NC}"
 echo -e "${GREEN}✓ Build complete${NC}"
 echo ""
 
+echo -e "${YELLOW}Step 11: Reinstating e2e tests from quarkus3...${NC}"
+mkdir -p "${OUTPUT_DIR}/src/test/java/org/acme/e2e"
+cp -r quarkus3/src/test/java/org/acme/e2e/* "${OUTPUT_DIR}/src/test/java/org/acme/e2e/"
+echo -e "${GREEN}✓ Copied e2e tests${NC}"
+echo ""
+
 echo -e "${GREEN}=== Conversion Complete ===${NC}"
 echo ""
 echo -e "${YELLOW}To run stress tests:${NC}"

--- a/spring-conversion.md
+++ b/spring-conversion.md
@@ -14,7 +14,8 @@ This is a great way of seeing that the Quarkus performance gains are because of 
 5. Start the app, with `(cd springboot3; quarkus dev)`. You'll see a failure and a crash.
 6. What's the problem? The `SpringBootApplication` class doesn't compile. The good news is it's not even needed with Quarkus. Delete it.
 7. The `config/` package (`L2CacheConfiguration`, `GraalVMConfig`, `L2CacheRuntimeHints`) also won't compile. These classes wire up Caffeine as a JCache provider for Hibernate's L2 cache and register GraalVM native-image hints — all Spring-specific plumbing. Quarkus handles Hibernate L2 cache automatically, so delete the whole `config/` directory: `rm -rf springboot3/src/main/java/org/acme/config`
-8. Try `quarkus dev` again, and everything should work. Visiting the endpoint in a browser should work.
+8. Replace `org.springframework.transaction.annotation.Transactional` with `jakarta.transaction.Transactional`. Quarkus doesn't support Spring's `@Transactional` ([quarkusio/quarkus#54089](https://github.com/quarkusio/quarkus/issues/54089)), but Jakarta's `@Transactional` preserves the same runtime behaviour. Replace `@Transactional(propagation = SUPPORTS, readOnly = true)` with `@Transactional(SUPPORTS)` — the `readOnly` hint has no Jakarta equivalent but doesn't affect correctness.
+9. Try `quarkus dev` again, and everything should work. Visiting the endpoint in a browser should work.
 
 ### Prod mode and stress testing
 

--- a/spring-conversion.md
+++ b/spring-conversion.md
@@ -13,7 +13,8 @@ This is a great way of seeing that the Quarkus performance gains are because of 
 4. Delete the tests, which are hard to convert ([for now](https://github.com/orgs/quarkusio/projects/60)): `rm -rf springboot3/src/test`
 5. Start the app, with `(cd springboot3; quarkus dev)`. You'll see a failure and a crash.
 6. What's the problem? The `SpringBootApplication` class doesn't compile. The good news is it's not even needed with Quarkus. Delete it.
-7. Try `quarkus dev` again, and everything should work. Visiting the endpoint in a browser should work.
+7. The `config/` package (`L2CacheConfiguration`, `GraalVMConfig`, `L2CacheRuntimeHints`) also won't compile. These classes wire up Caffeine as a JCache provider for Hibernate's L2 cache and register GraalVM native-image hints — all Spring-specific plumbing. Quarkus handles Hibernate L2 cache automatically, so delete the whole `config/` directory: `rm -rf springboot3/src/main/java/org/acme/config`
+8. Try `quarkus dev` again, and everything should work. Visiting the endpoint in a browser should work.
 
 ### Prod mode and stress testing
 

--- a/spring-conversion.md
+++ b/spring-conversion.md
@@ -10,7 +10,7 @@ This is a great way of seeing that the Quarkus performance gains are because of 
 1. Save the `pom.xml`, which we don't want to write by hand: `cp quarkus3-spring-compatibility/pom.xml spring-pom.xml` 
 2. Delete the compatibility project (we're about to recreate it from scratch!): `rm -rf quarkus3-spring-compatibility`
 3. Replace the spring pom: `mv spring-pom.xml springboot3/pom.xml`
-4. Delete the tests, which are hard to convert ([for now](https://github.com/orgs/quarkusio/projects/60)): `rm -rf springboot3/src/test`
+4. Delete the tests, which are hard to convert ([for now](https://github.com/orgs/quarkusio/projects/60)): `rm -rf springboot3/src/test`. To keep some coverage, you can copy across `quarkus3/src/test/java/org/acme/e2e` end-to-end tests after deleting the Spring ones.
 5. Start the app, with `(cd springboot3; quarkus dev)`. You'll see a failure and a crash.
 6. What's the problem? The `SpringBootApplication` class doesn't compile. The good news is it's not even needed with Quarkus. Delete it.
 7. The `config/` package (`L2CacheConfiguration`, `GraalVMConfig`, `L2CacheRuntimeHints`) also won't compile. These classes wire up Caffeine as a JCache provider for Hibernate's L2 cache and register GraalVM native-image hints — all Spring-specific plumbing. Quarkus handles Hibernate L2 cache automatically, so delete the whole `config/` directory: `rm -rf springboot3/src/main/java/org/acme/config`

--- a/spring-conversion.md
+++ b/spring-conversion.md
@@ -3,7 +3,9 @@
 It is possible to recreate the application parts of the `quarkus3-spring-compatibility` project with a few steps.
 This is a great way of seeing that the Quarkus performance gains are because of the runtime, not the programming model or code of the application.
 
-## Doing the conversion for dev mode
+## Manual conversion
+
+### Doing the conversion for dev mode
 
 1. Save the `pom.xml`, which we don't want to write by hand: `cp quarkus3-spring-compatibility/pom.xml spring-pom.xml` 
 2. Delete the compatibility project (we're about to recreate it from scratch!): `rm -rf quarkus3-spring-compatibility`
@@ -13,7 +15,7 @@ This is a great way of seeing that the Quarkus performance gains are because of 
 6. What's the problem? The `SpringBootApplication` class doesn't compile. The good news is it's not even needed with Quarkus. Delete it.
 7. Try `quarkus dev` again, and everything should work. Visiting the endpoint in a browser should work.
 
-## Prod mode and stress testing
+### Prod mode and stress testing
 
 Although everything is working in dev mode, if you look at the `application.yml`, you can see it's filled with spring config.
 There's no Quarkus database configured. In dev mode, that's fine, because Quarkus auto-starts one as a dev service, but that won't work in prod mode.
@@ -24,3 +26,26 @@ So we need to fill in config.
 3. Run the stress tests: `./scripts/stress.sh springboot3/target/quarkus-app/quarkus-run.jar`
 
 You should see that the throughput almost identical to the throughput of the 'normal' Quarkus app, and more than double that of the Quarkus-free Spring app.
+
+## Automated conversion
+
+You can run the automated conversion script to perform all the manual steps above:
+
+```shell
+./scripts/spring-conversion.sh [output-directory]
+```
+
+The script accepts an optional output directory argument:
+- **Default** (no argument): Creates/recreates `quarkus3-spring-compatibility` directory
+- **`springboot3`**: Converts the Spring Boot application in place
+
+Examples:
+```shell
+# Convert to quarkus3-spring-compatibility (default)
+./scripts/spring-conversion.sh
+
+# Convert springboot3 in place
+./scripts/spring-conversion.sh springboot3
+```
+
+This script will automatically execute all the conversion steps, build the application, and provide instructions for running stress tests.


### PR DESCRIPTION
See https://github.com/quarkusio/spring-quarkus-perf-comparison/issues/549. 

I'm expecting this to fail, but we can use it to evaluate fixes, and merge once it's green. (Or we could merge while it's red, on the basis that the redness is reflecting reality, and this is just a workflow.)

Once it's green, I'll also add some syncbot steps here or in the syncbot job so that it raises a PR against the `quarkus3-spring-compatibility` project to mirror across `spring3` changes (which will be trivial after running the script). 