### PR TITLE
Fix async-profiler to capture load test instead of warmup phase

### DIFF
--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -625,7 +625,7 @@ scripts:
                     suffix: ${{PROFILER_LOGFILE}}
                     format: ${{config.profiler.name}}
                     events: ${{config.profiler.events}}
-                    delay: 10s
+                    delay: 5s
         - script:
             name: watch-log
             async: true
@@ -633,7 +633,6 @@ scripts:
             log_file: ${{LOG_FILE}}
             log_regex: ${{APP_LOG_REGEX}}
         - wait-for: LOG_REGEX_REACHED
-        - signal: LOAD_STEADY_STATE_START
         - sh: |
             ${{LOAD_GEN_CMD_PREFIX}} jbang \
               -Dio.hyperfoil.rootdir=${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}} \
@@ -647,6 +646,11 @@ scripts:
         - sh: HF_PID=$! && echo $HF_PID
           then:
             - set-state: HF_PID
+        - script:
+            name: watch-hyperfoil-log
+            async: true
+          with:
+            log_file: ${{HYPERFOIL_LOGS_DIR}}/${{RUNTIME_NAME}}-${{ITERATION}}/hyperfoil.local.log
         - script:
             name: monitor-process
             async: true
@@ -789,7 +793,19 @@ scripts:
       timer:
         1m:
           - ctrlC
-          - abort: Log file ${{log_file}} didn't match regex ${{log_regex}} after 10 minutes
+          - abort: Log file ${{log_file}} didn't match regex ${{log_regex}} after 1 minute
+
+  watch-hyperfoil-log:
+    - sh: tail -F ${{log_file}}
+      watch:
+        - regex: "loadTest.*changing status.*RUNNING"
+          then:
+            - ctrlC
+            - signal: LOAD_STEADY_STATE_START
+      timer:
+        5m:
+          - ctrlC
+          - abort: Hyperfoil log ${{log_file}} didn't show loadTest RUNNING after 5 minutes
 
   monitor-processes:
     - set-signal: LOAD_TEST_COMPLETE 1


### PR DESCRIPTION
## Summary

- Since the Hyperfoil migration (commit a6e403e), async-profiler JFR/flamegraph captures the **warmup phase** instead of the **load test phase** because `LOAD_STEADY_STATE_START` fires immediately after app startup — before Hyperfoil even begins its 2-minute warmup
- Adds a dedicated `watch-hyperfoil-log` script that watches Hyperfoil's internal log (`hyperfoil.local.log`) for the `loadTest` phase transition to `RUNNING`, then fires the signal at the correct time
- Reduces the async-profiler delay from 10s to 5s since the signal now fires when the load test actually starts

## Changes

- **Removed** the premature `signal: LOAD_STEADY_STATE_START` that fired right after app startup
- **Added** `watch-hyperfoil-log` script: watches `hyperfoil.local.log` for `loadTest.*changing status.*RUNNING` with a 5m timer and `tail -F` (handles file not yet existing during Hyperfoil startup)
- **Added** async invocation of `watch-hyperfoil-log` after Hyperfoil is launched
- **Reduced** async-profiler delay from 10s to 5s
- **Fixed** `watch-log` abort message to match the actual 1m timer duration

## Test plan

- [x] Run benchmark with `--profiler flamegraph` and verify the run completes without the `watch-hyperfoil-log` aborting
- [ ] Verify async-profiler output captures data from the load test window (after warmup+cooldown), not the warmup phase
- [ ] Run benchmark without profiling to confirm no regressions

Fixes #600