### PR TITLE
Refactor: modularize profilers into a plugin-like architecture

### DIFF
--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -586,17 +586,11 @@ scripts:
         - script: sync-drop-fs-cache
         - set-signal: LOAD_STEADY_STATE_START 1
         - set-signal: LOG_REGEX_REACHED 1
-        - read-state: ${{config.profiler.name}}
-          then:
-            - regex: "^syncjfr$"
-              then:
-                - queue-download: ${{REPO_DIR}}/logs/jfr.${{RUNTIME_NAME}}-${{ITERATION}}.jfr
-                - sh: echo "${{RUNTIMECMD.runCmd}}" | sed 's#-jar#-XX:StartFlightRecording=filename=${{REPO_DIR}}/logs/jfr.${{RUNTIME_NAME}}-${{ITERATION}}.jfr,settings=profile,dumponexit=true -jar#'
-                  then:
-                    - set-state: SYNCJFR_RUN_CMD
-                - sh: ${{SYNCJFR_RUN_CMD}} &>${{LOG_FILE}} &
-              else:
-                - sh: ${{RUNTIMECMD.runCmd}} &>${{LOG_FILE}} &
+        # CUSTOM_RUN_CMD allows you to change the startup script within the function
+        - set-state: CUSTOM_RUN_CMD ${{RUNTIMECMD.runCmd}}
+        - script: ${{config.profiler.name}}-install
+        - log: "Starting SUT with command: ${{CUSTOM_RUN_CMD}}"
+        - sh: ${{CUSTOM_RUN_CMD}} &>${{LOG_FILE}} &
         - sh: PID=$!
         - sh: echo $PID
         - set-state: JVM_PID
@@ -607,25 +601,11 @@ scripts:
             runtime_name: ${{RUNTIME_NAME}}
             iteration: ${{ITERATION}}
         - log: JVM_PID = ${{JVM_PID}}
-        - read-state: ${{config.profiler.name}}
-          then:
-            - regex: "^(jfr|flamegraph)$"
-              then:
-                - script: async-profiler-install
-                - script: async-profiler-configure
-                - set-state:
-                    key: PROFILER_LOGFILE
-                    value: "${{RUNTIME_NAME}}-${{ITERATION}}.${{= '${{config.profiler.name}}' == 'jfr' ? 'jfr' : 'html' }}"
-                - script:
-                    name: async-profiler-run
-                    async: true
-                  with:
-                    wait_start: LOAD_STEADY_STATE_START
-                    pid: ${{JVM_PID}}
-                    suffix: ${{PROFILER_LOGFILE}}
-                    format: ${{config.profiler.name}}
-                    events: ${{config.profiler.events}}
-                    delay: 5s
+        - script:
+            name: ${{config.profiler.name}}-run
+            async: true
+          with:
+            delay: 5s
         - script:
             name: watch-log
             async: true

--- a/scripts/perf-lab/profilers/profiler-async-profiler.yml
+++ b/scripts/perf-lab/profilers/profiler-async-profiler.yml
@@ -1,14 +1,6 @@
-name: async-profiler #https://github.com/apangin/async-profiler.git
+# wrapper for profiler-flamegraph.yml and profiler-jfr.yml
+name: async-profiler
 scripts:
-  async-profiler-configure:
-    - read-state: ${{os}}
-      then:
-        - regex: linux
-          then:
-            - sh: echo 1 | sudo tee /proc/sys/kernel/perf_event_paranoid > /dev/null
-            - sh: echo 0 | sudo tee /proc/sys/kernel/kptr_restrict > /dev/null
-
-  # downloads the latest async-profiler release to ${{BASE_DIR}}/${{ASYNC_PROFILER}}
   download-unpack-async-profiler:
     - read-state: ${{os}}
       then:
@@ -29,23 +21,30 @@ scripts:
             - sh: mv ${{subDir}}/ ${{ASYNC_PROFILER}}
 
   async-profiler-install:
+    - read-state: ${{os}}
+      then:
+        - regex: linux
+          then:
+            - sh: echo 1 | sudo tee /proc/sys/kernel/perf_event_paranoid > /dev/null
+            - sh: echo 0 | sudo tee /proc/sys/kernel/kptr_restrict > /dev/null
     - sh: if test -d ${{ASYNC_PROFILER_DIR}} ; then rm -rf ${{ASYNC_PROFILER_DIR}}; fi
     - sh: cd ${{BASE_DIR}}
     - script: download-unpack-async-profiler
 
-  #waits for ${{WAIT_START}} then ${{DELAY}}, creates a profile using the configured parameters then downloads it immediately
-  #works with 3.x, not 2.x
   async-profiler-run:
+    - set-state:
+        key: PROFILER_LOGFILE
+        value: ${{REPO_DIR}}/logs/async-profiler-${{RUNTIME_NAME}}-${{ITERATION}}.${{extension}}
     - sh: cd ${{ASYNC_PROFILER_DIR}}
-    - wait-for: ${{wait_start:}} # don't wait by default
+    - wait-for: LOAD_STEADY_STATE_START
     - sleep: ${{delay:0}}
     - sh: >
         bin/asprof 
-        -d ${{duration:10}} 
-        -f ${{REPO_DIR}}/logs/${{format:flamegraph}}.${{suffix:html}} 
-        -o ${{format:flamegraph}} 
-        -e ${{events:cpu}} 
+        -d ${{duration:10}}
+        -f ${{PROFILER_LOGFILE}}
+        -o ${{config.profiler.name}}
+        -e ${{config.profiler.events}}
         ${{="${{enableTotal : }}".toLowerCase() == "true" ? "--total" : ""}} 
         --title ${{title:async-profiler}} 
-        ${{pid}}
-    - download: ${{REPO_DIR}}/logs/${{format:flamegraph}}.${{suffix:html}}
+        ${{JVM_PID}}
+    - download: ${{PROFILER_LOGFILE}}

--- a/scripts/perf-lab/profilers/profiler-flamegraph.yml
+++ b/scripts/perf-lab/profilers/profiler-flamegraph.yml
@@ -1,0 +1,14 @@
+name: flamegraph
+scripts:
+
+  flamegraph-install:
+    - script: async-profiler-install
+
+  flamegraph-run:
+    - script:
+        name: async-profiler-run
+        async: true
+      with:
+        extension: html
+        delay: ${{delay}}
+        duration: ${{duration}}

--- a/scripts/perf-lab/profilers/profiler-jfr.yml
+++ b/scripts/perf-lab/profilers/profiler-jfr.yml
@@ -1,0 +1,14 @@
+name: jfr
+scripts:
+
+  jfr-install:
+    - script: async-profiler-install
+
+  jfr-run:
+    - script:
+        name: async-profiler-run
+        async: true
+      with:
+        extension: jfr
+        delay: ${{delay}}
+        duration: ${{duration}}

--- a/scripts/perf-lab/profilers/profiler-none.yml
+++ b/scripts/perf-lab/profilers/profiler-none.yml
@@ -1,0 +1,7 @@
+name: none
+scripts:
+  none-install:
+    - log: "No profiler selected."
+
+  none-run:
+    - log: "No profiler to run."

--- a/scripts/perf-lab/profilers/profiler-perf-stat.yml
+++ b/scripts/perf-lab/profilers/profiler-perf-stat.yml
@@ -1,0 +1,20 @@
+name: perf-stat
+scripts:
+  perf-stat-install:
+    - log: "Preparing perf-stat profiler..."
+    - read-state: ${{os}}
+      then:
+        - regex: linux
+          then:
+            - sh: echo 1 | sudo tee /proc/sys/kernel/perf_event_paranoid > /dev/null
+            - sh: echo 0 | sudo tee /proc/sys/kernel/kptr_restrict > /dev/null
+    - set-state:
+        key: PROFILER_LOGFILE
+        value: "${{REPO_DIR}}/logs/perf-stat-${{RUNTIME_NAME}}-${{ITERATION}}.txt"
+    - queue-download: ${{PROFILER_LOGFILE}}
+
+  perf-stat-run:
+    - wait-for: LOAD_STEADY_STATE_START
+    - sleep: ${{delay:0}}
+    - log: "Running perf-stat profiler..."
+    - sh: perf stat -p ${{JVM_PID}} -- sleep ${{duration:10}} &> ${{PROFILER_LOGFILE}}

--- a/scripts/perf-lab/profilers/profiler-syncjfr.yml
+++ b/scripts/perf-lab/profilers/profiler-syncjfr.yml
@@ -1,0 +1,11 @@
+name: syncjfr
+scripts:
+  syncjfr-install:
+    - log: "Injecting JFR diagnostic flags into the JVM..."
+    - queue-download: ${{REPO_DIR}}/logs/jfr.${{RUNTIME_NAME}}-${{ITERATION}}.jfr
+    - sh: echo "${{RUNTIMECMD.runCmd}}" | sed 's#-jar#-XX:StartFlightRecording=filename=${{REPO_DIR}}/logs/jfr.${{RUNTIME_NAME}}-${{ITERATION}}.jfr,settings=profile,dumponexit=true -jar#'
+      then:
+        - set-state: CUSTOM_RUN_CMD
+
+  syncjfr-run:
+    - log: "JFR is native and was already started with the JVM. No action needed in the RUN step."

--- a/scripts/perf-lab/run-benchmarks.sh
+++ b/scripts/perf-lab/run-benchmarks.sh
@@ -269,6 +269,7 @@ ${JBANG_CMD} io.hyperfoil.tools:qDup:0.11.2 \
     ${EXTRA_QDUP_ARGS} \
     ./main.yml \
     ./helpers/ \
+    ./profilers/ \
     -S config.jvm.graalvm.home="${GRAALVM_HOME}" \
     -S config.jvm.graalvm.version=${GRAALVM_VERSION} \
     -S config.jvm.home="${JAVA_HOME}" \
@@ -452,10 +453,10 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         ;;
 
       --profiler)
-        if [[ "$2" =~ ^(none|jfr|syncjfr|flamegraph)$ ]]; then
+        if [[ "$2" =~ ^(none|jfr|syncjfr|flamegraph|perf-stat)$ ]]; then
           PROFILER="$2"
         else
-          echo "!! [ERROR] --profiler option must be one of (none, jfr, syncjfr, flamegraph)!!"
+          echo "!! [ERROR] --profiler option must be one of (none, jfr, syncjfr, flamegraph, perf-stat)!!"
           exit_abnormal
         fi
         shift 2


### PR DESCRIPTION
This PR is still a draft because it requires @franz1981 review.
- I already tested locally.

### **Motivation**

The core `main.yml` pipeline was becoming cluttered and difficult to maintain due to a monolithic `if/else` regex block handling profiler selection. Adding new profiling tools required modifying the core pipeline directly, increasing complexity and the risk of introducing errors.

### **The New Feature**

* **Modular Architecture:** Extracted all profiler logic out of `main.yml` and reorganized it into a plugin-based architecture.

* **Dedicated Configurations:** Created isolated configuration files for each profiler (`profiler-flamegraph.yml`, `profiler-jfr.yml`, `profiler-syncjfr.yml`, `profiler-none.yml`, and `profiler-perf-stat.yml`) located in a new `./profilers/` directory.

* **`perf stat` Support:** Added a new profiler option to capture hardware performance counter statistics using Linux `perf stat`.


### **Why This is Better Than Before**

* **Cleaner Core Workflow:** `main.yml` no longer cares about *which* profiler is running; it simply executes dynamic hooks (`${{config.profiler.name}}-install` and `-run`), keeping the main script drastically shorter and easier to read.


* **Highly Scalable:** Adding new profilers in the future is now trivial. You only need to drop a new YAML file into the `./profilers/` folder and update the bash script options, completely avoiding changes to the core workflow.


* **Separation of Concerns:** Each profiler now entirely manages its own dependencies, wait states, and custom run commands (like `syncjfr` injecting JVM flags) natively within its own file.