### PR TITLE
Switch warmup to multi-cycle: 10 x (15s load + 15s cooldown)

### DIFF
--- a/scripts/perf-lab/load-tests/load-test-fixed-threads-read-all.hf.yml
+++ b/scripts/perf-lab/load-tests/load-test-fixed-threads-read-all.hf.yml
@@ -3,19 +3,28 @@
 # =============================================================================
 #
 # This configuration file defines a load test scenario for the application's read-all
-# endpoint. It includes a warmup phase followed by a delay, then the main load test phase.
+# endpoint. It uses multiple warmup+cooldown cycles to ensure the C2 compiler has
+# enough CPU time to finish compiling hot methods before the measurement phase.
 #
-# All phases target the same HTTP endpoint.
+# Each warmup burst exercises the code paths under full closed-loop load, and each
+# cooldown gives the C2 compiler threads CPU time to drain the compilation queue.
+# After all cycles complete, the load test measures peak throughput.
 #
-# This is to replace how we did things exactly as before:
-# warmup
-# wrk -t 2 -c 100 -d 2m --timeout 2m http://localhost:8080/fruits
+# Why multi-cycle warmup:
+#   On CPU-bound workloads with many platform threads (e.g., 100 connections on
+#   4 cores), C2 compiler threads are starved during a single continuous warmup.
+#   The application runs suboptimal C1-compiled code for the entire warmup and
+#   never reaches peak performance before measurement begins. Multi-cycle warmup
+#   gives C2 periodic CPU time during cooldown gaps to compile hot methods.
 #
-# cooldown
-# sleep 30s
-#
-# loadTest
-# wrk -t 2 -c 100 -d 30s --timeout 30s http://localhost:8080/fruits
+# Breaking changes from the previous single-warmup format:
+#   - Total warmup time increases from ~2.5min to ~5.5min per runtime
+#   - Hyperfoil series CSVs use warmup_NNN naming (e.g., warmup_000.getAllFruits.3.series.csv)
+#     instead of warmup.getAllFruits.2.series.csv
+#   - WARMUP_MAX_DURATION parameter removed (maxIterations controls total warmup)
+#   - metrics.json format and loadTest phase structure are unchanged
+#   - The quarkusio/benchmarks graphics-generator only reads metrics.json
+#     (load.avThroughput, load.throughput, etc.) and is NOT affected
 #
 # Configurable Parameters:
 # ----------------------------------
@@ -23,17 +32,17 @@
 #                           Options: http, https
 # HOST                   - Target server hostname (default: localhost)
 # PORT                   - Target server port (default: 8080)
-# CONNECTIONS            - Number of HTTP connections (-c wrk param) (default: 100)
+# CONNECTIONS             - Number of HTTP connections (default: 100)
 # HIDE_WARMUP_PHASE      - Hide the warmup phase details (default: false)
 # PATH                   - HTTP endpoint path to test (default: /fruits)
-# WARMUP_DURATION        - Duration of the warmup phase (-d wrk param) (default: 2m)
-# WARMUP_MAX_DURATION    - Maximum duration of the warmup phase (default: 4m)
-# WARMUP_PAUSE_DURATION  - Duration of the pause between warmup and main load test (default: 30s)
-# WARMUP_REQUEST_TIMEOUT - Timeout for warmup requests (--timeout wrk param) (default: 2m)
-# LOAD_REQUEST_TIMEOUT   - Timeout for main load test requests (--timeout wrk param) (default: 30s)
-# LOAD_DURATION          - Duration of the main load test phase (-d wrk param) (default: 30s)
+# WARMUP_CYCLES          - Number of warmup+cooldown cycles (default: 10)
+# WARMUP_DURATION        - Duration of each warmup burst (default: 15s)
+# WARMUP_PAUSE_DURATION  - Duration of each cooldown pause (default: 15s)
+# WARMUP_REQUEST_TIMEOUT - Timeout for warmup requests (default: 2m)
+# LOAD_REQUEST_TIMEOUT   - Timeout for main load test requests (default: 30s)
+# LOAD_DURATION          - Duration of the main load test phase (default: 30s)
 # LOAD_MAX_DURATION      - Maximum duration of the main load test phase (default: 1m)
-# THREADS                - Number of threads to use (-t wrk param) (default: 2)
+# THREADS                - Number of threads to use (default: 2)
 #
 # Usage:
 # ------
@@ -59,9 +68,12 @@ phases:
   - warmup:
       always:
         users: !param CONNECTIONS 100
-        duration: !param WARMUP_DURATION 2m
-        maxDuration: !param WARMUP_MAX_DURATION 4m
+        duration: !param WARMUP_DURATION 15s
+        maxIterations: !param WARMUP_CYCLES 10
         isWarmup: !param HIDE_WARMUP_PHASE false
+        startAfter:
+          - phase: cooldown
+            iteration: previous
         scenario:
           maxRequests: 1
           maxSequences: 1
@@ -75,15 +87,16 @@ phases:
 
   - cooldown:
       noop:
-        startAfter: warmup
-        duration: !param WARMUP_PAUSE_DURATION 30s
+        maxIterations: !param WARMUP_CYCLES 10
+        startAfter:
+          - phase: warmup
+            iteration: same
+        duration: !param WARMUP_PAUSE_DURATION 15s
 
   - logStart:
       atOnce:
         users: 1
-        startAfterStrict:
-          - warmup
-          - cooldown
+        startAfterStrict: cooldown
         scenario:
           maxRequests: 1
           maxSequences: 1

--- a/scripts/perf-lab/main.yml
+++ b/scripts/perf-lab/main.yml
@@ -803,9 +803,9 @@ scripts:
             - ctrlC
             - signal: LOAD_STEADY_STATE_START
       timer:
-        5m:
+        10m:
           - ctrlC
-          - abort: Hyperfoil log ${{log_file}} didn't show loadTest RUNNING after 5 minutes
+          - abort: Hyperfoil log ${{log_file}} didn't show loadTest RUNNING after 10 minutes
 
   monitor-processes:
     - set-signal: LOAD_TEST_COMPLETE 1


### PR DESCRIPTION
On CPU-bound workloads with many platform threads (e.g., Spring Boot with 100 connections on 4 cores), C2 compiler threads are starved during a single continuous warmup. The application never reaches peak performance before the measurement phase begins.

Multi-cycle warmup alternates short load bursts with cooldown gaps. Each cooldown gives C2 compiler threads CPU time to drain the compilation queue. After 10 cycles (5 minutes total), hot methods are fully compiled and the load test measures peak throughput.

Validated on the perf lab: spring4-jvm goes from ~7,850 TPS (old warmup) to ~8,500 TPS (multi-cycle). Quarkus reaches peak by cycle 2-3.

Uses Hyperfoil maxIterations for compact YAML. All parameters have configurable defaults via !param (WARMUP_CYCLES, WARMUP_DURATION, WARMUP_PAUSE_DURATION). No changes to run-benchmarks.sh or Jenkins config needed.

Also increases the watch-hyperfoil-log timeout from 5m to 10m to accommodate the longer warmup.

Fixes #633 